### PR TITLE
feat: streamline Drive consent with unified OAuth flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,20 +1,121 @@
+import json
 import os
-from fastapi import FastAPI
-from dotenv import load_dotenv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
 
-# .env 파일에서 환경 변수(API Key) 불러오기
+import httpx
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
 load_dotenv()
 
-# FastAPI 인스턴스 생성
-app = FastAPI()
+GOOGLE_CLIENT_ID = os.getenv('GOOGLE_CLIENT_ID')
+GOOGLE_CLIENT_SECRET = os.getenv('GOOGLE_CLIENT_SECRET')
+GOOGLE_REDIRECT_URI = os.getenv('GOOGLE_REDIRECT_URI', 'postmessage')
 
-# 루트 엔드포인트 ('/')
-@app.get("/")
-def read_root():
-    # OpenAI API Key 로딩 되었는지 확인
-    api_key = os.getenv("OPENAI_API_KEY")
+raw_origins = os.getenv('CORS_ALLOW_ORIGINS', '*')
+ALLOWED_ORIGINS = [origin.strip() for origin in raw_origins.split(',') if origin.strip()]
+if not ALLOWED_ORIGINS:
+    ALLOWED_ORIGINS = ['*']
+
+TOKENS_FILE = Path(__file__).resolve().parent / 'google_tokens.json'
+
+
+class ExchangeRequest(BaseModel):
+    code: str = Field(..., description='Google OAuth authorization code')
+
+
+class TokenStore:
+    def __init__(self, filepath: Path):
+        self.filepath = filepath
+
+    def save(self, payload: dict[str, Any]) -> None:
+        self.filepath.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def read(self) -> dict[str, Any] | None:
+        if not self.filepath.exists():
+            return None
+        try:
+            return json.loads(self.filepath.read_text())
+        except json.JSONDecodeError:
+            return None
+
+
+store = TokenStore(TOKENS_FILE)
+
+app = FastAPI(title='Drive Auth Service')
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+
+@app.get('/')
+def read_root() -> dict[str, str]:
     return {
-        "Project": "TTA-AI-Project",
-        "Status": "Running",
-        "OpenAI API Key": f"{api_key[:5]}..." if api_key else "API 키 못찾았지롱"
+        'project': 'TTA-AI-Project',
+        'status': 'running',
     }
+
+
+@app.get('/auth/google/tokens')
+def get_saved_tokens() -> dict[str, Any]:
+    saved = store.read()
+    if not saved:
+        raise HTTPException(status_code=404, detail='저장된 토큰이 없습니다.')
+    return saved
+
+
+@app.post('/auth/google/exchange')
+async def exchange_authorization_code(payload: ExchangeRequest) -> dict[str, Any]:
+    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+        raise HTTPException(
+            status_code=500,
+            detail='Google OAuth 환경 변수가 설정되어 있지 않습니다. 서버 설정을 확인하세요.',
+        )
+
+    token_endpoint = 'https://oauth2.googleapis.com/token'
+    data = {
+        'client_id': GOOGLE_CLIENT_ID,
+        'client_secret': GOOGLE_CLIENT_SECRET,
+        'code': payload.code,
+        'grant_type': 'authorization_code',
+        'redirect_uri': GOOGLE_REDIRECT_URI,
+    }
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            token_endpoint,
+            data=data,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        )
+
+    if response.status_code != 200:
+        try:
+            error_detail = response.json()
+        except ValueError:
+            error_detail = {'error': response.text}
+        raise HTTPException(status_code=response.status_code, detail=error_detail)
+
+    token_payload = response.json()
+    expires_in = int(token_payload.get('expires_in', 0))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+    stored_payload = {
+        'accessToken': token_payload.get('access_token'),
+        'refreshToken': token_payload.get('refresh_token'),
+        'expiresAt': expires_at.isoformat(),
+        'scope': token_payload.get('scope'),
+        'tokenType': token_payload.get('token_type'),
+    }
+
+    store.save(stored_payload)
+
+    return stored_payload

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,177 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.page {
+  width: min(480px, 100%);
+  padding: 3.5rem 3rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow:
+    0 25px 45px rgba(15, 23, 42, 0.15),
+    0 2px 10px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.page__eyebrow {
+  display: inline-flex;
+  align-self: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.2);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.page__title {
+  margin: 0;
+  font-size: clamp(2rem, 2.5vw + 1.5rem, 2.6rem);
+  line-height: 1.25;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.page__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.google-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 2rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.4), rgba(241, 245, 249, 0.9));
+}
+
+.google-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  text-align: center;
+}
+
+.google-card__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.google-card__description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #334155;
+}
+
+.google-card__helper {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.google-card__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.google-card__status strong {
+  font-size: 1rem;
+}
+
+.google-card__status--error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.google-card__status--success {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  text-align: left;
+}
+
+.google-card__drive-button {
+  align-self: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: white;
+  background: linear-gradient(135deg, #0f9d58, #0b8043);
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(15, 128, 67, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.google-card__drive-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 128, 67, 0.3);
+}
+
+.google-card__drive-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
+.google-card__token-details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0.75rem 0 0;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(7, 89, 133, 0.08);
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.google-card__token-details div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.google-card__token-details dt {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.google-card__token-details dd {
+  margin: 0;
+  color: #0f172a;
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 2.75rem 1.75rem;
+    border-radius: 22px;
+    gap: 2rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .google-card {
+    padding: 1.75rem;
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,20 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { GoogleLoginCard } from './components/GoogleLoginCard'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+    <div className="page">
+      <header className="page__header">
+        <span className="page__eyebrow">Google Drive 연결</span>
+        <h1 className="page__title">한 번의 승인으로 로그인과 Drive 접근까지</h1>
+        <p className="page__subtitle">
+          아래 버튼을 누르면 Google 계정 확인과 동시에 Drive 파일 접근 권한을 요청합니다.
+          승인하면 백엔드가 access/refresh 토큰을 교환해 안전하게 저장합니다.
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </header>
+
+      <GoogleLoginCard />
+    </div>
   )
 }
 

--- a/frontend/src/components/GoogleLoginCard.tsx
+++ b/frontend/src/components/GoogleLoginCard.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+interface GoogleCodeResponse {
+  code: string
+}
+
+interface TokenExchangeResponse {
+  accessToken: string
+  refreshToken?: string
+  expiresAt: string
+  scope: string
+}
+
+type CodeClient = {
+  requestCode: () => void
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        oauth2?: {
+          initCodeClient: (config: {
+            client_id: string
+            scope: string
+            callback: (response: GoogleCodeResponse) => void
+            ux_mode?: 'popup' | 'redirect'
+            access_type?: 'online' | 'offline'
+            prompt?: string
+            state?: string
+            redirect_uri?: string
+          }) => CodeClient
+        }
+      }
+    }
+  }
+}
+
+const GOOGLE_SCRIPT_ID = 'google-identity-services'
+
+export function GoogleLoginCard() {
+  const [isReady, setIsReady] = useState(false)
+  const [isRequesting, setIsRequesting] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [tokenResponse, setTokenResponse] = useState<TokenExchangeResponse | null>(null)
+  const codeClientRef = useRef<CodeClient | null>(null)
+
+  const apiBaseUrl = useMemo(() => {
+    return import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, '') || 'http://localhost:8000'
+  }, [])
+
+  const exchangeAuthorizationCode = useCallback(
+    async (code: string) => {
+      setIsRequesting(true)
+      setError(null)
+      setStatusMessage('백엔드에서 Drive 토큰을 교환하는 중입니다…')
+      setTokenResponse(null)
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/auth/google/exchange`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code }),
+        })
+
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => null)
+          const message =
+            (errorPayload && (errorPayload.detail || errorPayload.error)) ||
+            '서버에서 토큰을 발급받는 중 오류가 발생했습니다.'
+          throw new Error(message)
+        }
+
+        const payload = (await response.json()) as TokenExchangeResponse
+        setTokenResponse(payload)
+        setStatusMessage('Drive 권한이 연결되었어요. 아래에서 발급된 토큰 정보를 확인할 수 있습니다.')
+      } catch (requestError) {
+        setError(
+          requestError instanceof Error
+            ? requestError.message
+            : '알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.',
+        )
+        setStatusMessage(null)
+      } finally {
+        setIsRequesting(false)
+      }
+    },
+    [apiBaseUrl],
+  )
+
+  useEffect(() => {
+    let isCancelled = false
+    let scriptElement: HTMLScriptElement | null = document.getElementById(
+      GOOGLE_SCRIPT_ID,
+    ) as HTMLScriptElement | null
+
+    const initializeGoogleClient = () => {
+      if (isCancelled) {
+        return
+      }
+
+      const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
+      if (!clientId) {
+        setError(
+          'Google OAuth 클라이언트 ID가 설정되어 있지 않습니다. .env 파일에 VITE_GOOGLE_CLIENT_ID를 추가하세요.',
+        )
+        return
+      }
+
+      const oauth2 = window.google?.accounts?.oauth2
+      if (!oauth2?.initCodeClient) {
+        setError('Google OAuth 클라이언트를 초기화할 수 없습니다. SDK 구성을 확인하세요.')
+        return
+      }
+
+      codeClientRef.current = oauth2.initCodeClient({
+        client_id: clientId,
+        scope: 'openid email profile https://www.googleapis.com/auth/drive.file',
+        access_type: 'offline',
+        prompt: 'consent',
+        ux_mode: 'popup',
+        redirect_uri: 'postmessage',
+        callback: async (response: GoogleCodeResponse) => {
+          if (!response.code) {
+            setError('Google로부터 인가 코드를 받지 못했습니다. 다시 시도해 주세요.')
+            setStatusMessage(null)
+            return
+          }
+          await exchangeAuthorizationCode(response.code)
+        },
+      })
+
+      setError(null)
+      setIsReady(true)
+    }
+
+    const handleScriptError = () => {
+      if (!isCancelled) {
+        setError('Google OAuth 스크립트를 불러오는 데 실패했습니다.')
+      }
+    }
+
+    if (scriptElement) {
+      if (window.google?.accounts?.oauth2?.initCodeClient) {
+        initializeGoogleClient()
+      } else {
+        scriptElement.addEventListener('load', initializeGoogleClient)
+        scriptElement.addEventListener('error', handleScriptError)
+      }
+    } else {
+      scriptElement = document.createElement('script')
+      scriptElement.id = GOOGLE_SCRIPT_ID
+      scriptElement.src = 'https://accounts.google.com/gsi/client'
+      scriptElement.async = true
+      scriptElement.defer = true
+      scriptElement.addEventListener('load', initializeGoogleClient)
+      scriptElement.addEventListener('error', handleScriptError)
+      document.head.appendChild(scriptElement)
+    }
+
+    return () => {
+      isCancelled = true
+      if (scriptElement) {
+        scriptElement.removeEventListener('load', initializeGoogleClient)
+        scriptElement.removeEventListener('error', handleScriptError)
+      }
+    }
+  }, [exchangeAuthorizationCode])
+
+  const handleConnectClick = useCallback(() => {
+    if (!codeClientRef.current) {
+      setError('Google OAuth 클라이언트가 아직 준비되지 않았습니다. 잠시 후 다시 시도하세요.')
+      return
+    }
+
+    setError(null)
+    setTokenResponse(null)
+    setStatusMessage('Google 팝업에서 계정을 선택하고 권한을 승인해 주세요.')
+    codeClientRef.current.requestCode()
+  }, [])
+
+  return (
+    <section className="google-card">
+      <div className="google-card__content">
+        <h2 className="google-card__title">Google 계정과 Drive 권한 동시 연결</h2>
+        <p className="google-card__description">
+          Google OAuth 2.0 코드 흐름을 사용해 계정 인증과 Drive 파일 접근 권한을 한 번에 요청합니다.
+          승인하면 백엔드가 access/refresh 토큰을 교환해 안전하게 저장합니다.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        className="google-card__drive-button"
+        onClick={handleConnectClick}
+        disabled={!isReady || isRequesting}
+      >
+        {isRequesting ? '권한 요청 중…' : 'Google 계정으로 Drive 연결하기'}
+      </button>
+
+      {!isReady && !error && (
+        <p className="google-card__helper">Google OAuth 클라이언트를 불러오는 중입니다…</p>
+      )}
+
+      {statusMessage && !error && (
+        <div className="google-card__status" role="status">
+          <strong>진행 중</strong>
+          <span>{statusMessage}</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="google-card__status google-card__status--error" role="alert">
+          <strong>문제가 발생했습니다.</strong>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {tokenResponse && (
+        <div className="google-card__status google-card__status--success" role="status">
+          <strong>Drive 권한 연결 완료</strong>
+          <span>
+            Access Token 만료: {new Date(tokenResponse.expiresAt).toLocaleString()} / Refresh Token
+            저장됨
+          </span>
+          <dl className="google-card__token-details">
+            <div>
+              <dt>Access Token</dt>
+              <dd>{tokenResponse.accessToken}</dd>
+            </div>
+            {tokenResponse.refreshToken && (
+              <div>
+                <dt>Refresh Token</dt>
+                <dd>{tokenResponse.refreshToken}</dd>
+              </div>
+            )}
+            <div>
+              <dt>Scope</dt>
+              <dd>{tokenResponse.scope}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,47 @@
+* {
+  box-sizing: border-box;
+}
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #0f172a;
+  background-color: #e2e8f0;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 55%),
+    radial-gradient(circle at bottom, rgba(249, 115, 22, 0.25), transparent 55%),
+    linear-gradient(160deg, #f8fafc 0%, #e2e8f0 100%);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+#root {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+@media (max-width: 640px) {
+  body {
+    padding: 2.5rem 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the separate Google sign-in and Drive consent steps with a single OAuth code flow button
- update the login card messaging to explain simultaneous account verification and Drive access
- simplify the landing copy and styles after removing the redundant divider and sections

## Testing
- npm run build --prefix frontend
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d7ac915e6483309d60480b327ae872