### PR TITLE
Implement Google Drive OAuth login flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,20 +1,183 @@
-import os
-from fastapi import FastAPI
-from dotenv import load_dotenv
+from __future__ import annotations
 
-# .env 파일에서 환경 변수(API Key) 불러오기
+import logging
+import os
+import secrets
+from pathlib import Path
+from typing import Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import httpx
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+from .token_store import TokenStorage
+
+logger = logging.getLogger(__name__)
+
 load_dotenv()
 
-# FastAPI 인스턴스 생성
+GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+GOOGLE_SCOPES = (
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.file",
+)
+
+CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI")
+
+FRONTEND_REDIRECT_URL = os.getenv("FRONTEND_REDIRECT_URL", "http://localhost:5173/")
+
+TOKENS_PATH = Path(os.getenv("GOOGLE_TOKEN_PATH", Path(__file__).resolve().parent / "google_tokens.json"))
+token_storage = TokenStorage(Path(TOKENS_PATH))
+
+state_store: set[str] = set()
+
+
+def _ensure_credentials() -> None:
+    if not CLIENT_ID or not CLIENT_SECRET or not REDIRECT_URI:
+        raise HTTPException(
+            status_code=500,
+            detail="Google OAuth 환경 변수가 올바르게 설정되지 않았습니다.",
+        )
+
+
+def _build_frontend_redirect(status: str, message: Optional[str] = None) -> str:
+    parsed = list(urlparse(FRONTEND_REDIRECT_URL))
+    query: Dict[str, str] = dict(parse_qsl(parsed[4]))
+    query["auth"] = status
+    if message:
+        query["message"] = message
+    parsed[4] = urlencode(query, doseq=True)
+    return urlunparse(parsed)
+
+
 app = FastAPI()
 
-# 루트 엔드포인트 ('/')
+
+parsed_frontend = urlparse(FRONTEND_REDIRECT_URL)
+frontend_origin = f"{parsed_frontend.scheme}://{parsed_frontend.netloc}" if parsed_frontend.scheme else "*"
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[frontend_origin] if frontend_origin != "" else ["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
 @app.get("/")
-def read_root():
-    # OpenAI API Key 로딩 되었는지 확인
-    api_key = os.getenv("OPENAI_API_KEY")
+def read_root() -> Dict[str, str]:
     return {
-        "Project": "TTA-AI-Project",
-        "Status": "Running",
-        "OpenAI API Key": f"{api_key[:5]}..." if api_key else "API 키 못찾았지롱"
+        "project": "TTA-AI-Project",
+        "status": "running",
     }
+
+
+@app.get("/auth/google/login")
+def google_login() -> RedirectResponse:
+    _ensure_credentials()
+
+    state = secrets.token_urlsafe(32)
+    state_store.add(state)
+
+    params = {
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(GOOGLE_SCOPES),
+        "access_type": "offline",
+        "prompt": "consent",
+        "include_granted_scopes": "true",
+        "state": state,
+    }
+
+    auth_url = f"{GOOGLE_AUTH_ENDPOINT}?{urlencode(params)}"
+    return RedirectResponse(auth_url)
+
+
+@app.get("/auth/google/callback")
+async def google_callback(request: Request) -> RedirectResponse:
+    _ensure_credentials()
+
+    params = request.query_params
+    error = params.get("error")
+    state = params.get("state")
+
+    if error:
+        message = params.get("error_description", "Google 인증이 취소되었습니다.")
+        redirect_url = _build_frontend_redirect("error", message)
+        return RedirectResponse(redirect_url)
+
+    code = params.get("code")
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="code 또는 state 매개변수가 누락되었습니다.")
+
+    if state not in state_store:
+        raise HTTPException(status_code=400, detail="유효하지 않은 state 값입니다.")
+
+    state_store.remove(state)
+
+    data = {
+        "code": code,
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "redirect_uri": REDIRECT_URI,
+        "grant_type": "authorization_code",
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(GOOGLE_TOKEN_ENDPOINT, data=data)
+
+    if response.is_error:
+        logger.error("Google token exchange failed: %s", response.text)
+        redirect_url = _build_frontend_redirect("error", "Google 토큰 발급에 실패했습니다.")
+        return RedirectResponse(redirect_url)
+
+    tokens = response.json()
+    token_storage.save(tokens)
+
+    redirect_url = _build_frontend_redirect("success")
+    return RedirectResponse(redirect_url)
+
+
+@app.get("/auth/google/tokens")
+def read_tokens() -> JSONResponse:
+    _ensure_credentials()
+
+    stored = token_storage.load()
+    if not stored:
+        raise HTTPException(status_code=404, detail="저장된 토큰이 없습니다.")
+
+    payload = stored.to_dict()
+    payload.pop("access_token", None)
+    payload.pop("refresh_token", None)
+
+    return JSONResponse(payload)
+
+
+@app.get("/auth/google/callback/success")
+def success_page() -> HTMLResponse:
+    return HTMLResponse(
+        """
+        <html>
+            <head>
+                <meta charset="utf-8" />
+                <title>Google 인증 완료</title>
+                <style>
+                    body { font-family: sans-serif; padding: 48px; text-align: center; }
+                    h1 { color: #2563eb; }
+                </style>
+            </head>
+            <body>
+                <h1>Google Drive 인증이 완료되었습니다.</h1>
+                <p>이 창은 닫으셔도 됩니다.</p>
+            </body>
+        </html>
+        """
+    )

--- a/backend/app/token_store.py
+++ b/backend/app/token_store.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class StoredTokens:
+    """Representation of the Google OAuth tokens saved on disk."""
+
+    access_token: str
+    refresh_token: Optional[str]
+    scope: str
+    token_type: str
+    expires_in: int
+    saved_at: datetime
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "StoredTokens":
+        return cls(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            scope=data["scope"],
+            token_type=data["token_type"],
+            expires_in=int(data["expires_in"]),
+            saved_at=datetime.fromisoformat(data["saved_at"]),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "scope": self.scope,
+            "token_type": self.token_type,
+            "expires_in": self.expires_in,
+            "saved_at": self.saved_at.isoformat(),
+        }
+
+
+class TokenStorage:
+    """Persist Google OAuth tokens to a JSON file on disk."""
+
+    def __init__(self, file_path: Path) -> None:
+        self._file_path = file_path
+        self._file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def save(self, payload: Dict[str, Any]) -> StoredTokens:
+        tokens = StoredTokens(
+            access_token=payload["access_token"],
+            refresh_token=payload.get("refresh_token"),
+            scope=payload.get("scope", ""),
+            token_type=payload.get("token_type", "Bearer"),
+            expires_in=int(payload.get("expires_in", 0)),
+            saved_at=datetime.now(timezone.utc),
+        )
+
+        with self._file_path.open("w", encoding="utf-8") as fp:
+            json.dump(tokens.to_dict(), fp, ensure_ascii=False, indent=2)
+
+        return tokens
+
+    def load(self) -> Optional[StoredTokens]:
+        if not self._file_path.exists():
+            return None
+
+        with self._file_path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+
+        return StoredTokens.from_dict(data)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -78,10 +78,68 @@
   color: #334155;
 }
 
+.google-card__scopes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
+.google-card__scopes li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.google-card__scopes li::before {
+  content: '✓';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #2563eb;
+  font-size: 0.85rem;
+}
+
 .google-card__button {
   display: flex;
   justify-content: center;
   min-height: 46px;
+}
+
+.google-card__signin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.google-card__signin:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 26px rgba(37, 99, 235, 0.3);
+  background: #1d4ed8;
+}
+
+.google-card__signin:disabled {
+  cursor: not-allowed;
+  background: #93c5fd;
+  box-shadow: none;
 }
 
 .google-card__helper {


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to launch the Google OAuth consent screen, exchange codes for Drive tokens, and persist them
- introduce a JSON-based token storage helper for saving access and refresh tokens
- replace the frontend GIS widget with a redirecting login button and status messaging for the OAuth flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7bd6d14c08330b641efd3e807b414