### PR TITLE
Automate Drive project folder creation for PDF uploads

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -265,6 +265,318 @@
   line-height: 1.6;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 2rem;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.modal__content {
+  position: relative;
+  width: min(560px, 100%);
+  max-height: min(640px, 100%);
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.92));
+  box-shadow:
+    0 30px 60px rgba(15, 23, 42, 0.25),
+    0 10px 25px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  overflow-y: auto;
+}
+
+.modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.modal__description {
+  margin: 0;
+  color: #475569;
+  font-size: 1rem;
+}
+
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal__helper-text {
+  font-size: 0.95rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.modal__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.modal__input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 1rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.modal__input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.modal__fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.modal__segmented {
+  display: inline-flex;
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 0.25rem;
+  background: rgba(148, 163, 184, 0.18);
+  gap: 0.25rem;
+}
+
+.modal__segment {
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: transparent;
+  color: #475569;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.modal__segment--active {
+  background: #2563eb;
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.22);
+}
+
+.modal__segment:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.modal__checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.modal__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.modal__checkbox input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #2563eb;
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal__button {
+  min-width: 100px;
+  padding: 0.75rem 1.4rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: white;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.modal__button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+
+.modal__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.modal__button--primary {
+  border-color: transparent;
+  background: #2563eb;
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.25);
+}
+
+.modal__button--primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.modal__error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #b91c1c;
+}
+
+.file-uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.file-uploader__dropzone {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  border-radius: 18px;
+  border: 2px dashed rgba(148, 163, 184, 0.6);
+  background: rgba(248, 250, 252, 0.9);
+  color: #475569;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.file-uploader__dropzone:hover {
+  border-color: #2563eb;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.12);
+}
+
+.file-uploader__dropzone--active {
+  border-color: #2563eb;
+  background: rgba(219, 234, 254, 0.4);
+}
+
+.file-uploader__input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.file-uploader__prompt {
+  font-size: 1rem;
+  color: #1f2937;
+}
+
+.file-uploader__help {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.file-uploader__error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #b91c1c;
+}
+
+.file-uploader__files {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.file-uploader__file {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: #fff;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+  gap: 1rem;
+}
+
+.file-uploader__file-name {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.file-uploader__file-size {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.file-uploader__remove {
+  border: none;
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.file-uploader__remove:hover {
+  background: rgba(239, 68, 68, 0.2);
+  transform: translateY(-1px);
+}
+
 .drive-projects__list {
   margin: 0;
   padding: 0;
@@ -386,5 +698,18 @@
 
   .drive-card {
     padding: 1.75rem;
+  }
+
+  .modal {
+    padding: 1.5rem;
+  }
+
+  .modal__content {
+    padding: 2rem;
+    border-radius: 20px;
+  }
+
+  .file-uploader__dropzone {
+    padding: 1.5rem;
   }
 }

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from 'react'
+import type { ChangeEvent, DragEvent } from 'react'
+
+export type FileType = 'pdf' | 'txt' | 'jpg' | 'csv' | 'html'
+
+interface FileTypeInfo {
+  label: string
+  accept: string[]
+  extensions: string[]
+}
+
+export const FILE_TYPE_OPTIONS: Record<FileType, FileTypeInfo> = {
+  pdf: {
+    label: 'PDF',
+    accept: ['.pdf', 'application/pdf'],
+    extensions: ['pdf'],
+  },
+  txt: {
+    label: 'TXT',
+    accept: ['.txt', 'text/plain'],
+    extensions: ['txt'],
+  },
+  jpg: {
+    label: 'JPG',
+    accept: ['.jpg', '.jpeg', 'image/jpeg'],
+    extensions: ['jpg', 'jpeg'],
+  },
+  csv: {
+    label: 'CSV',
+    accept: ['.csv', 'text/csv'],
+    extensions: ['csv'],
+  },
+  html: {
+    label: 'HTML',
+    accept: ['.html', '.htm', 'text/html'],
+    extensions: ['html', 'htm'],
+  },
+}
+
+export const ALL_FILE_TYPES = Object.keys(FILE_TYPE_OPTIONS) as FileType[]
+
+interface FileUploaderProps {
+  allowedTypes: FileType[]
+  files: File[]
+  onChange: (files: File[]) => void
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / 1024 ** exponent
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`
+}
+
+function createFileKey(file: File) {
+  return `${file.name}-${file.size}-${file.lastModified}`
+}
+
+export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProps) {
+  const [isDragging, setIsDragging] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const activeTypes = allowedTypes.length > 0 ? allowedTypes : ALL_FILE_TYPES
+
+  const acceptValue = useMemo(() => {
+    return activeTypes.flatMap((type) => FILE_TYPE_OPTIONS[type].accept).join(',')
+  }, [activeTypes])
+
+  const allowedLabels = useMemo(() => {
+    return activeTypes.map((type) => FILE_TYPE_OPTIONS[type].label).join(', ')
+  }, [activeTypes])
+
+  const handleDragOver = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    if (!isDragging) {
+      setIsDragging(true)
+    }
+  }
+
+  const handleDragLeave = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    if (isDragging) {
+      setIsDragging(false)
+    }
+  }
+
+  const addFiles = (incoming: File[]) => {
+    if (incoming.length === 0) {
+      return
+    }
+
+    const allowed: File[] = []
+    const rejected: string[] = []
+    const existingKeys = new Set(files.map(createFileKey))
+
+    incoming.forEach((file) => {
+      const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
+      const matchesType = activeTypes.some((type) => {
+        const info = FILE_TYPE_OPTIONS[type]
+        return info.extensions.includes(extension) || info.accept.includes(file.type)
+      })
+
+      if (!matchesType) {
+        rejected.push(file.name)
+        return
+      }
+
+      const key = createFileKey(file)
+      if (existingKeys.has(key)) {
+        return
+      }
+
+      existingKeys.add(key)
+      allowed.push(file)
+    })
+
+    if (rejected.length > 0) {
+      setError(`허용되지 않은 형식입니다: ${rejected.join(', ')}`)
+    } else {
+      setError(null)
+    }
+
+    if (allowed.length > 0) {
+      onChange([...files, ...allowed])
+    }
+  }
+
+  const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    setIsDragging(false)
+    const droppedFiles = Array.from(event.dataTransfer?.files ?? [])
+    addFiles(droppedFiles)
+  }
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.target.files ?? [])
+    addFiles(selected)
+    event.target.value = ''
+  }
+
+  const handleRemove = (index: number) => {
+    const nextFiles = files.filter((_, currentIndex) => currentIndex !== index)
+    onChange(nextFiles)
+  }
+
+  return (
+    <div className="file-uploader">
+      <label
+        className={`file-uploader__dropzone${isDragging ? ' file-uploader__dropzone--active' : ''}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <input
+          type="file"
+          className="file-uploader__input"
+          accept={acceptValue}
+          multiple
+          onChange={handleInputChange}
+        />
+        <div className="file-uploader__prompt">
+          <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
+        </div>
+        <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
+      </label>
+
+      {error && <p className="file-uploader__error" role="alert">{error}</p>}
+
+      {files.length > 0 && (
+        <ul className="file-uploader__files">
+          {files.map((file, index) => (
+            <li key={createFileKey(file)} className="file-uploader__file">
+              <div>
+                <span className="file-uploader__file-name">{file.name}</span>
+                <span className="file-uploader__file-size">{formatBytes(file.size)}</span>
+              </div>
+              <button
+                type="button"
+                className="file-uploader__remove"
+                onClick={() => handleRemove(index)}
+                aria-label={`${file.name} 삭제`}
+              >
+                삭제
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useId } from 'react'
+import type { PropsWithChildren } from 'react'
+
+interface ModalProps extends PropsWithChildren {
+  open: boolean
+  title: string
+  description?: string
+  onClose: () => void
+}
+
+export function Modal({ open, title, description, onClose, children }: ModalProps) {
+  const titleId = useId()
+  const descriptionId = useId()
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onClose])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className="modal" role="presentation">
+      <div className="modal__overlay" onClick={onClose} aria-hidden="true" />
+      <div
+        className="modal__content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+      >
+        <header className="modal__header">
+          <h2 className="modal__title" id={titleId}>
+            {title}
+          </h2>
+          {description && (
+            <p className="modal__description" id={descriptionId}>
+              {description}
+            </p>
+          )}
+        </header>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ProjectCreationModal.tsx
+++ b/frontend/src/components/ProjectCreationModal.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+
+import { getBackendUrl } from '../config'
+import { Modal } from './Modal'
+import { FileUploader } from './FileUploader'
+import type { FileType } from './FileUploader'
+
+interface ProjectCreationModalProps {
+  open: boolean
+  folderId?: string
+  onClose: () => void
+  onSuccess?: () => void
+  backendUrl?: string
+}
+
+const PDF_ONLY: FileType[] = ['pdf']
+
+export function ProjectCreationModal({
+  open,
+  folderId,
+  onClose,
+  onSuccess,
+  backendUrl,
+}: ProjectCreationModalProps) {
+  const [files, setFiles] = useState<File[]>([])
+  const [formError, setFormError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const resolvedBackendUrl = useMemo(() => backendUrl ?? getBackendUrl(), [backendUrl])
+
+  useEffect(() => {
+    if (!open) {
+      setFiles([])
+      setFormError(null)
+      setSubmitError(null)
+      setIsSubmitting(false)
+    }
+  }, [open])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFormError(null)
+    setSubmitError(null)
+
+    if (files.length === 0) {
+      setFormError('최소 한 개의 PDF 파일을 업로드해주세요.')
+      return
+    }
+
+    const formData = new FormData()
+    if (folderId) {
+      formData.append('folder_id', folderId)
+    }
+    files.forEach((file) => {
+      formData.append('files', file)
+    })
+
+    setIsSubmitting(true)
+    try {
+      const response = await fetch(`${resolvedBackendUrl}/drive/projects`, {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!response.ok) {
+        let detail = '프로젝트 생성에 실패했습니다. 잠시 후 다시 시도해주세요.'
+        try {
+          const payload = await response.json()
+          if (payload && typeof payload.detail === 'string') {
+            detail = payload.detail
+          }
+        } catch {
+          const text = await response.text()
+          if (text) {
+            detail = text
+          }
+        }
+        throw new Error(detail)
+      }
+
+      onClose()
+      onSuccess?.()
+    } catch (error) {
+      const fallback =
+        error instanceof Error
+          ? error.message
+          : '프로젝트 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      setSubmitError(fallback)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={isSubmitting ? () => {} : onClose}
+      title="새 프로젝트 생성"
+      description="PDF를 업로드하면 'GS-X-X-XXXX' 폴더와 필수 하위 폴더가 자동으로 만들어집니다."
+    >
+      <form className="modal__form" onSubmit={handleSubmit}>
+        <div className="modal__body">
+          <p className="modal__helper-text">
+            업로드한 파일은 생성되는 프로젝트의 ‘0. 사전 자료’ 폴더에 저장됩니다.
+          </p>
+
+          <FileUploader allowedTypes={PDF_ONLY} files={files} onChange={setFiles} />
+
+          {formError && (
+            <p className="modal__error" role="alert">
+              {formError}
+            </p>
+          )}
+          {submitError && (
+            <p className="modal__error" role="alert">
+              {submitError}
+            </p>
+          )}
+        </div>
+
+        <footer className="modal__footer">
+          <button type="button" className="modal__button" onClick={onClose} disabled={isSubmitting}>
+            취소
+          </button>
+          <button type="submit" className="modal__button modal__button--primary" disabled={isSubmitting}>
+            {isSubmitting ? '생성 중…' : '생성'}
+          </button>
+        </footer>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/drive/DriveAccountBadge.tsx
+++ b/frontend/src/components/drive/DriveAccountBadge.tsx
@@ -1,0 +1,13 @@
+interface DriveAccountBadgeProps {
+  displayName: string
+  email?: string | null
+}
+
+export function DriveAccountBadge({ displayName, email }: DriveAccountBadgeProps) {
+  return (
+    <div className="drive-page__account" role="note">
+      <span className="drive-page__account-name">{displayName}</span>
+      {email && <span className="drive-page__account-email">{email}</span>}
+    </div>
+  )
+}

--- a/frontend/src/components/drive/DriveActionButton.tsx
+++ b/frontend/src/components/drive/DriveActionButton.tsx
@@ -1,0 +1,21 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+type DriveActionVariant = 'primary' | 'compact'
+
+interface DriveActionButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: DriveActionVariant
+}
+
+export function DriveActionButton({ variant = 'primary', className, ...props }: DriveActionButtonProps) {
+  const classes = ['drive-create']
+  if (variant === 'primary') {
+    classes.push('drive-create--primary')
+  }
+  if (variant === 'compact') {
+    classes.push('drive-create--compact')
+  }
+  if (className) {
+    classes.push(className)
+  }
+  return <button type="button" {...props} className={classes.join(' ')} />
+}

--- a/frontend/src/components/drive/DriveCard.tsx
+++ b/frontend/src/components/drive/DriveCard.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from 'react'
+
+type DriveCardVariant = 'default' | 'loading' | 'error'
+
+interface DriveCardProps extends PropsWithChildren {
+  variant?: DriveCardVariant
+  banner?: string | null
+  role?: string
+  ariaBusy?: boolean
+}
+
+export function DriveCard({ variant = 'default', banner, role, ariaBusy, children }: DriveCardProps) {
+  const classes = ['drive-card']
+  if (variant === 'loading') {
+    classes.push('drive-card--loading')
+  }
+  if (variant === 'error') {
+    classes.push('drive-card--error')
+  }
+
+  return (
+    <section className={classes.join(' ')} role={role} aria-busy={ariaBusy}>
+      {banner && <div className="drive-card__banner drive-card__banner--success">{banner}</div>}
+      {children}
+    </section>
+  )
+}

--- a/frontend/src/components/drive/DriveEmptyState.tsx
+++ b/frontend/src/components/drive/DriveEmptyState.tsx
@@ -1,0 +1,15 @@
+import { DriveActionButton } from './DriveActionButton'
+
+interface DriveEmptyStateProps {
+  onCreateClick: () => void
+}
+
+export function DriveEmptyState({ onCreateClick }: DriveEmptyStateProps) {
+  return (
+    <div className="drive-empty">
+      <p className="drive-empty__title">아직 프로젝트 폴더가 없어요.</p>
+      <p className="drive-empty__subtitle">첫 프로젝트를 생성해 팀 작업을 시작해 보세요.</p>
+      <DriveActionButton onClick={onCreateClick}>프로젝트 생성</DriveActionButton>
+    </div>
+  )
+}

--- a/frontend/src/components/drive/DriveProjectsList.tsx
+++ b/frontend/src/components/drive/DriveProjectsList.tsx
@@ -1,0 +1,30 @@
+import type { DriveProject } from '../../types/drive'
+
+interface DriveProjectsListProps {
+  projects: DriveProject[]
+}
+
+export function DriveProjectsList({ projects }: DriveProjectsListProps) {
+  return (
+    <ul className="drive-projects__list">
+      {projects.map((project) => {
+        const modified = project.modifiedTime ? new Date(project.modifiedTime) : null
+        const formatted = modified && !Number.isNaN(modified.getTime())
+          ? new Intl.DateTimeFormat('ko-KR', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+            }).format(modified)
+          : null
+
+        return (
+          <li key={project.id}>
+            <button type="button" className="drive-projects__item">
+              <span className="drive-projects__name">{project.name}</span>
+              {formatted && <span className="drive-projects__meta">최근 수정 {formatted}</span>}
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,15 @@
+interface PageHeaderProps {
+  eyebrow?: string
+  title: string
+  subtitle?: string
+}
+
+export function PageHeader({ eyebrow, title, subtitle }: PageHeaderProps) {
+  return (
+    <header className="page__header">
+      {eyebrow && <span className="page__eyebrow">{eyebrow}</span>}
+      <h1 className="page__title">{title}</h1>
+      {subtitle && <p className="page__subtitle">{subtitle}</p>}
+    </header>
+  )
+}

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -1,0 +1,5 @@
+import type { PropsWithChildren } from 'react'
+
+export function PageLayout({ children }: PropsWithChildren) {
+  return <div className="page">{children}</div>
+}

--- a/frontend/src/pages/DriveSetupPage.tsx
+++ b/frontend/src/pages/DriveSetupPage.tsx
@@ -1,58 +1,32 @@
-import '../App.css'
 import { useEffect, useMemo, useState } from 'react'
 
 import { DRIVE_AUTH_STORAGE_KEY, getBackendUrl } from '../config'
-
-interface DriveProject {
-  id: string
-  name: string
-  createdTime?: string
-  modifiedTime?: string
-}
-
-interface DriveSetupResponse {
-  folderCreated: boolean
-  folderId: string
-  folderName: string
-  projects: DriveProject[]
-  account?: {
-    googleId: string
-    displayName: string
-    email?: string | null
-  }
-}
+import { DriveActionButton } from '../components/drive/DriveActionButton'
+import { DriveAccountBadge } from '../components/drive/DriveAccountBadge'
+import { DriveCard } from '../components/drive/DriveCard'
+import { DriveEmptyState } from '../components/drive/DriveEmptyState'
+import { DriveProjectsList } from '../components/drive/DriveProjectsList'
+import { PageHeader } from '../components/layout/PageHeader'
+import { PageLayout } from '../components/layout/PageLayout'
+import { ProjectCreationModal } from '../components/ProjectCreationModal'
+import type { DriveSetupResponse } from '../types/drive'
 
 type ViewState = 'loading' | 'ready' | 'error'
-
-function formatDateTime(value?: string) {
-  if (!value) {
-    return null
-  }
-
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return null
-  }
-
-  return new Intl.DateTimeFormat('ko-KR', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(parsed)
-}
 
 export function DriveSetupPage() {
   const backendUrl = useMemo(() => getBackendUrl(), [])
   const [viewState, setViewState] = useState<ViewState>('loading')
-  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [errorMessage, setErrorMessage] = useState('')
   const [result, setResult] = useState<DriveSetupResponse | null>(null)
   const [reloadIndex, setReloadIndex] = useState(0)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
-  // B) 마운트 시점에 세션 키만 조용히 정리
   useEffect(() => {
     try {
       sessionStorage.removeItem(DRIVE_AUTH_STORAGE_KEY)
-    } catch (e) {
-      console.error('failed to clear auth message', e)
+    } catch (error) {
+      console.error('failed to clear auth message', error)
     }
   }, [])
 
@@ -118,89 +92,86 @@ export function DriveSetupPage() {
     setReloadIndex((index) => index + 1)
   }
 
+  const handleOpenModal = () => {
+    setSuccessMessage(null)
+    setIsModalOpen(true)
+  }
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false)
+  }
+
+  const handleProjectCreated = () => {
+    setSuccessMessage('새 프로젝트 폴더를 생성했습니다.')
+    setReloadIndex((index) => index + 1)
+  }
+
   const projects = result?.projects ?? []
+  const folderName = result?.folderName ?? 'gs'
 
   return (
-    <div className="page drive-page">
-      <header className="page__header">
-        <span className="page__eyebrow">Google Drive 프로젝트</span>
-        <h1 className="page__title">프로젝트</h1>
-      </header>
+    <PageLayout>
+      <div className="drive-page">
+        <PageHeader eyebrow="Google Drive 프로젝트" title="프로젝트" />
 
-      {result?.account && (
-        <div className="drive-page__account" role="note">
-          <span className="drive-page__account-name">{result.account.displayName}</span>
-          {result.account.email && (
-            <span className="drive-page__account-email">{result.account.email}</span>
-          )}
-        </div>
-      )}
+        {result?.account && (
+          <DriveAccountBadge
+            displayName={result.account.displayName}
+            email={result.account.email}
+          />
+        )}
 
-      {viewState === 'loading' && (
-        <section className="drive-card drive-card--loading" aria-busy="true">
-          <div className="drive-card__spinner" aria-hidden="true" />
-          <p className="drive-card__loading-text">Google Drive에서 폴더 상태를 확인하는 중입니다…</p>
-        </section>
-      )}
+        {viewState === 'loading' && (
+          <DriveCard variant="loading" ariaBusy>
+            <div className="drive-card__spinner" aria-hidden="true" />
+            <p className="drive-card__loading-text">Google Drive에서 폴더 상태를 확인하는 중입니다…</p>
+          </DriveCard>
+        )}
 
-      {viewState === 'error' && (
-        <section className="drive-card drive-card--error" role="alert">
-          <h2 className="drive-card__title">Drive 상태를 불러오지 못했습니다</h2>
-          <p className="drive-card__description">{errorMessage}</p>
-          <button type="button" className="drive-create drive-create--primary" onClick={handleRetry}>
-            다시 시도
-          </button>
-        </section>
-      )}
+        {viewState === 'error' && (
+          <DriveCard variant="error" role="alert">
+            <h2 className="drive-card__title">Drive 상태를 불러오지 못했습니다</h2>
+            <p className="drive-card__description">{errorMessage}</p>
+            <DriveActionButton onClick={handleRetry}>다시 시도</DriveActionButton>
+          </DriveCard>
+        )}
 
-      {viewState === 'ready' && result && (
-        <section className="drive-card">
-          {result.folderCreated && (
-            <div className="drive-card__banner drive-card__banner--success" role="status">
-              '{result.folderName}' 폴더를 Google Drive에 새로 만들었습니다.
-            </div>
-          )}
+        {viewState === 'ready' && result && (
+          <DriveCard
+            banner={
+              result.folderCreated
+                ? `'${result.folderName}' 폴더를 Google Drive에 새로 만들었습니다.`
+                : successMessage
+            }
+          >
+            <h2 className="drive-card__title">프로젝트 선택</h2>
+            <p className="drive-card__description">
+              {projects.length > 0
+                ? '사용할 프로젝트를 선택하거나 새 프로젝트를 생성해 주세요.'
+                : `현재 '${folderName}' 폴더 안에 프로젝트가 없습니다.`}
+            </p>
 
-          <h2 className="drive-card__title">프로젝트 선택</h2>
-          <p className="drive-card__description">
-            {projects.length > 0
-              ? '사용할 프로젝트를 선택하거나 새 프로젝트를 생성해 주세요.'
-              : `현재 '${result.folderName}' 폴더 안에 프로젝트가 없습니다.`}
-          </p>
+            {projects.length > 0 ? (
+              <>
+                <DriveProjectsList projects={projects} />
+                <DriveActionButton variant="compact" onClick={handleOpenModal}>
+                  새 프로젝트 만들기
+                </DriveActionButton>
+              </>
+            ) : (
+              <DriveEmptyState onCreateClick={handleOpenModal} />
+            )}
+          </DriveCard>
+        )}
+      </div>
 
-          {projects.length > 0 ? (
-            <>
-              <ul className="drive-projects__list">
-                {projects.map((project) => {
-                  const modified = formatDateTime(project.modifiedTime)
-                  return (
-                    <li key={project.id}>
-                      <button type="button" className="drive-projects__item">
-                        <span className="drive-projects__name">{project.name}</span>
-                        {modified && (
-                          <span className="drive-projects__meta">최근 수정 {modified}</span>
-                        )}
-                      </button>
-                    </li>
-                  )
-                })}
-              </ul>
-
-              <button type="button" className="drive-create drive-create--compact">
-                새 프로젝트 만들기
-              </button>
-            </>
-          ) : (
-            <div className="drive-empty">
-              <p className="drive-empty__title">아직 프로젝트 폴더가 없어요.</p>
-              <p className="drive-empty__subtitle">첫 프로젝트를 생성해 팀 작업을 시작해 보세요.</p>
-              <button type="button" className="drive-create drive-create--primary">
-                프로젝트 생성
-              </button>
-            </div>
-          )}
-        </section>
-      )}
-    </div>
+      <ProjectCreationModal
+        open={isModalOpen}
+        onClose={handleCloseModal}
+        onSuccess={handleProjectCreated}
+        folderId={result?.folderId}
+        backendUrl={backendUrl}
+      />
+    </PageLayout>
   )
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,18 +1,16 @@
-import '../App.css'
 import { GoogleLoginCard } from '../components/GoogleLoginCard'
+import { PageHeader } from '../components/layout/PageHeader'
+import { PageLayout } from '../components/layout/PageLayout'
 
 export function LoginPage() {
   return (
-    <div className="page">
-      <header className="page__header">
-        <span className="page__eyebrow">Google Drive 연결</span>
-        <h1 className="page__title">먼저 구글 계정으로 로그인하세요</h1>
-        <p className="page__subtitle">
-          프로젝트에서 Google Drive 권한을 사용하려면 Google 계정을 통해 인증을 완료해야 합니다. 아래 버튼을 눌러 안전하게 로그인하세요.
-        </p>
-      </header>
-
+    <PageLayout>
+      <PageHeader
+        eyebrow="Google Drive 연결"
+        title="먼저 구글 계정으로 로그인하세요"
+        subtitle="프로젝트에서 Google Drive 권한을 사용하려면 Google 계정을 통해 인증을 완료해야 합니다. 아래 버튼을 눌러 안전하게 로그인하세요."
+      />
       <GoogleLoginCard />
-    </div>
+    </PageLayout>
   )
 }

--- a/frontend/src/types/drive.ts
+++ b/frontend/src/types/drive.ts
@@ -1,0 +1,20 @@
+export interface DriveProject {
+  id: string
+  name: string
+  createdTime?: string
+  modifiedTime?: string
+}
+
+export interface DriveAccount {
+  googleId: string
+  displayName: string
+  email?: string | null
+}
+
+export interface DriveSetupResponse {
+  folderCreated: boolean
+  folderId: string
+  folderName: string
+  projects: DriveProject[]
+  account?: DriveAccount
+}


### PR DESCRIPTION
## Summary
- generate GS-X-X-XXXX Drive project folders with the mandated child directories and upload PDFs into the 자료 bucket
- add Drive API helpers to create subfolders and store uploaded PDFs while logging the resulting project metadata
- simplify the project creation modal for PDF-only uploads and update success messaging in the Drive setup page

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d8aa562378833095b73334ac0cf517