### PR TITLE
Add project management page with side navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -717,6 +717,126 @@
   }
 }
 
+.project-management-page {
+  width: min(1200px, 100%);
+  min-height: 70vh;
+  display: flex;
+  gap: 2.5rem;
+  padding: 2.5rem 2rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow:
+    0 25px 45px rgba(15, 23, 42, 0.15),
+    0 2px 10px rgba(15, 23, 42, 0.08);
+}
+
+.project-management-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding-right: 1rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.project-management-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.project-management-overview__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.project-management-overview__name {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #0f172a;
+  word-break: keep-all;
+}
+
+.project-management-menu__list,
+.project-management-menu__sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-management-menu__sublist {
+  margin-top: 0.75rem;
+  padding-left: 1.5rem;
+  gap: 0.75rem;
+}
+
+.project-management-menu__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 1rem;
+  color: #1f2937;
+}
+
+.project-management-menu__item + .project-management-menu__item {
+  margin-top: 1rem;
+}
+
+.project-management-menu__item--secondary {
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.project-management-menu__prefix {
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1;
+  margin-top: 0.15rem;
+}
+
+.project-management-menu__label {
+  font-weight: 500;
+}
+
+.project-management-menu__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-content {
+  flex: 1;
+  border-radius: 20px;
+  background: rgba(241, 245, 249, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+@media (max-width: 960px) {
+  .project-management-page {
+    flex-direction: column;
+    padding: 2rem 1.5rem;
+  }
+
+  .project-management-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+    padding-bottom: 1.5rem;
+  }
+
+  .project-management-content {
+    width: 100%;
+    min-height: 320px;
+  }
+}
+
 @media (max-width: 640px) {
   .page {
     padding: 2.75rem 1.75rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState } from 'react'
 import { listen, navigate } from './navigation'
 import { DriveSetupPage } from './pages/DriveSetupPage'
 import { LoginPage } from './pages/LoginPage'
-
-const KNOWN_PATHS = new Set(['/', '/drive'])
+import { ProjectManagementPage } from './pages/ProjectManagementPage'
 
 function App() {
   const [pathname, setPathname] = useState<string>(() => window.location.pathname || '/')
@@ -18,11 +17,19 @@ function App() {
   }, [])
 
   useEffect(() => {
-    if (!KNOWN_PATHS.has(pathname)) {
+    const isKnownPath = pathname === '/' || pathname === '/drive' || pathname.startsWith('/projects/')
+
+    if (!isKnownPath) {
       navigate('/', { replace: true })
       setPathname('/')
     }
   }, [pathname])
+
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)$/)
+
+  if (projectMatch) {
+    return <ProjectManagementPage projectId={decodeURIComponent(projectMatch[1])} />
+  }
 
   if (pathname === '/drive') {
     return <DriveSetupPage />

--- a/frontend/src/components/drive/DriveProjectsList.tsx
+++ b/frontend/src/components/drive/DriveProjectsList.tsx
@@ -1,4 +1,5 @@
 import type { DriveProject } from '../../types/drive'
+import { navigate } from '../../navigation'
 
 interface DriveProjectsListProps {
   projects: DriveProject[]
@@ -18,7 +19,21 @@ export function DriveProjectsList({ projects }: DriveProjectsListProps) {
 
         return (
           <li key={project.id}>
-            <button type="button" className="drive-projects__item">
+            <button
+              type="button"
+              className="drive-projects__item"
+              onClick={() => {
+                const params = new URLSearchParams()
+                if (project.name) {
+                  params.set('name', project.name)
+                }
+                navigate(
+                  `/projects/${encodeURIComponent(project.id)}${
+                    params.size > 0 ? `?${params.toString()}` : ''
+                  }`,
+                )
+              }}
+            >
               <span className="drive-projects__name">{project.name}</span>
               {formatted && <span className="drive-projects__meta">최근 수정 {formatted}</span>}
             </button>

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react'
+
+interface ProjectManagementPageProps {
+  projectId: string
+}
+
+export function ProjectManagementPage({ projectId }: ProjectManagementPageProps) {
+  const projectName = useMemo(() => {
+    const searchParams = new URLSearchParams(window.location.search)
+    const name = searchParams.get('name')
+    return name ?? projectId
+  }, [projectId])
+
+  return (
+    <div className="project-management-page">
+      <aside className="project-management-sidebar">
+        <div className="project-management-overview">
+          <span className="project-management-overview__label">프로젝트</span>
+          <strong className="project-management-overview__name">{projectName}</strong>
+        </div>
+
+        <nav aria-label="프로젝트 관리 메뉴" className="project-management-menu">
+          <ul className="project-management-menu__list">
+            <li className="project-management-menu__item project-management-menu__item--primary">
+              <span aria-hidden="true" className="project-management-menu__prefix">
+                -
+              </span>
+              <span className="project-management-menu__label">기능 및 TC 생성 메뉴</span>
+            </li>
+            <li className="project-management-menu__item project-management-menu__item--primary">
+              <span aria-hidden="true" className="project-management-menu__prefix">
+                -
+              </span>
+              <div className="project-management-menu__group">
+                <span className="project-management-menu__label">결함리포트 생성</span>
+                <ul className="project-management-menu__sublist">
+                  <li className="project-management-menu__item project-management-menu__item--secondary">
+                    <span aria-hidden="true" className="project-management-menu__prefix">
+                      &gt;
+                    </span>
+                    <span className="project-management-menu__label">결함</span>
+                  </li>
+                  <li className="project-management-menu__item project-management-menu__item--secondary">
+                    <span aria-hidden="true" className="project-management-menu__prefix">
+                      &gt;
+                    </span>
+                    <span className="project-management-menu__label">보안성</span>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li className="project-management-menu__item project-management-menu__item--primary">
+              <span aria-hidden="true" className="project-management-menu__prefix">
+                -
+              </span>
+              <span className="project-management-menu__label">성능평가리포트 생성</span>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+      <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠" />
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- enable Drive project selections to navigate to a dedicated management route
- add a project management page that surfaces the requested sidebar menu skeleton
- style the new layout so the sidebar and empty content area render consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8cbf4b1bc83308716528aa8bc32b5