### PR TITLE
Revamp project management layout with interactive sidebar

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -717,6 +717,312 @@
   }
 }
 
+
+.project-management-layout {
+  min-height: 100vh;
+  width: 100%;
+  background: linear-gradient(160deg, #f1f5f9 0%, #e2e8f0 45%, #f8fafc 100%);
+  padding: clamp(2rem, 4vw, 4rem) clamp(1.5rem, 6vw, 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.project-management-header {
+  display: flex;
+  justify-content: center;
+}
+
+.project-management-header__content {
+  max-width: 900px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.project-management-header__eyebrow {
+  display: inline-flex;
+  align-self: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.project-management-header__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw + 1rem, 3.4rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.project-management-header__subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: #334155;
+}
+
+.project-management-page {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  display: flex;
+  gap: clamp(2rem, 4vw, 3rem);
+  padding: clamp(2rem, 3vw, 3rem);
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  box-shadow:
+    0 30px 60px rgba(15, 23, 42, 0.12),
+    0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.project-management-sidebar {
+  width: min(320px, 28vw);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding-right: clamp(0.5rem, 2vw, 1.5rem);
+  border-right: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.project-management-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.project-management-overview__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.project-management-overview__name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  word-break: keep-all;
+}
+
+.project-management-menu__list,
+.project-management-menu__sublist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-menu__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #1f2937;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.project-management-menu__item:hover {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.project-management-menu__item--secondary {
+  font-size: 0.95rem;
+  color: #475569;
+  padding-left: 1.1rem;
+}
+
+.project-management-menu__item--active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.1));
+  color: #1d4ed8;
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.15);
+}
+
+.project-management-menu__prefix {
+  font-weight: 700;
+  color: currentColor;
+  line-height: 1;
+}
+
+.project-management-menu__label {
+  flex: 1;
+}
+
+.project-management-content {
+  flex: 1;
+  border-radius: 24px;
+  background: linear-gradient(160deg, rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.75));
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: clamp(2rem, 4vw, 3rem);
+  display: flex;
+  align-items: stretch;
+}
+
+.project-management-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.project-management-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-section__title {
+  margin: 0;
+  font-size: clamp(1.7rem, 1.5vw + 1.3rem, 2.3rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.project-management-section__description {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #475569;
+}
+
+.project-management-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.project-management-upload__dropzone {
+  position: relative;
+  border: 2px dashed rgba(59, 130, 246, 0.35);
+  border-radius: 20px;
+  background: rgba(59, 130, 246, 0.05);
+  padding: clamp(2.5rem, 4vw, 3.5rem) clamp(1.5rem, 3vw, 2.5rem);
+  text-align: center;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.project-management-upload__dropzone:hover {
+  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.project-management-upload__input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.project-management-upload__label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  color: #2563eb;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.project-management-upload__icon {
+  font-size: 2rem;
+}
+
+.project-management-upload__text {
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.project-management-upload__helper {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.project-management-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.project-management-primary-button,
+.project-management-secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 14px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.project-management-primary-button {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.3);
+}
+
+.project-management-primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 36px rgba(37, 99, 235, 0.35);
+}
+
+.project-management-secondary-button {
+  background: rgba(15, 23, 42, 0.05);
+  color: #0f172a;
+}
+
+.project-management-secondary-button:hover {
+  background: rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+@media (max-width: 960px) {
+  .project-management-page {
+    flex-direction: column;
+  }
+
+  .project-management-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+    padding-bottom: 1.75rem;
+  }
+
+  .project-management-content {
+    width: 100%;
+  }
+}
+
 @media (max-width: 640px) {
   .page {
     padding: 2.75rem 1.75rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,7 @@ import { useEffect, useState } from 'react'
 import { listen, navigate } from './navigation'
 import { DriveSetupPage } from './pages/DriveSetupPage'
 import { LoginPage } from './pages/LoginPage'
-
-const KNOWN_PATHS = new Set(['/', '/drive'])
+import { ProjectManagementPage } from './pages/ProjectManagementPage'
 
 function App() {
   const [pathname, setPathname] = useState<string>(() => window.location.pathname || '/')
@@ -18,11 +17,19 @@ function App() {
   }, [])
 
   useEffect(() => {
-    if (!KNOWN_PATHS.has(pathname)) {
+    const isKnownPath = pathname === '/' || pathname === '/drive' || pathname.startsWith('/projects/')
+
+    if (!isKnownPath) {
       navigate('/', { replace: true })
       setPathname('/')
     }
   }, [pathname])
+
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)$/)
+
+  if (projectMatch) {
+    return <ProjectManagementPage projectId={decodeURIComponent(projectMatch[1])} />
+  }
 
   if (pathname === '/drive') {
     return <DriveSetupPage />

--- a/frontend/src/components/drive/DriveProjectsList.tsx
+++ b/frontend/src/components/drive/DriveProjectsList.tsx
@@ -1,4 +1,5 @@
 import type { DriveProject } from '../../types/drive'
+import { navigate } from '../../navigation'
 
 interface DriveProjectsListProps {
   projects: DriveProject[]
@@ -18,7 +19,21 @@ export function DriveProjectsList({ projects }: DriveProjectsListProps) {
 
         return (
           <li key={project.id}>
-            <button type="button" className="drive-projects__item">
+            <button
+              type="button"
+              className="drive-projects__item"
+              onClick={() => {
+                const params = new URLSearchParams()
+                if (project.name) {
+                  params.set('name', project.name)
+                }
+                navigate(
+                  `/projects/${encodeURIComponent(project.id)}${
+                    params.size > 0 ? `?${params.toString()}` : ''
+                  }`,
+                )
+              }}
+            >
               <span className="drive-projects__name">{project.name}</span>
               {formatted && <span className="drive-projects__meta">최근 수정 {formatted}</span>}
             </button>

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from 'react'
+
+interface ProjectManagementPageProps {
+  projectId: string
+}
+
+type SectionLevel = 'primary' | 'secondary'
+
+interface SectionDefinition {
+  id: string
+  label: string
+  level: SectionLevel
+  parentId?: string
+  description: string
+  actionLabel: string
+}
+
+const sections: SectionDefinition[] = [
+  {
+    id: 'feature-tc',
+    label: '기능 및 TC 생성 메뉴',
+    level: 'primary',
+    description: '테스트 커버리지를 빠르게 준비할 수 있도록 필요한 문서나 자료를 업로드하고 기능 및 테스트케이스를 생성하세요.',
+    actionLabel: '기능 및 TC 생성하기',
+  },
+  {
+    id: 'defect-report',
+    label: '결함리포트 생성',
+    level: 'primary',
+    description: '결함 리포트 생성을 위한 전반적인 자료를 업로드하고 자동화된 리포트를 한 번에 생성합니다.',
+    actionLabel: '결함 리포트 생성하기',
+  },
+  {
+    id: 'defect-report-issue',
+    label: '결함',
+    parentId: 'defect-report',
+    level: 'secondary',
+    description: '버그 및 이슈 항목을 업로드하면 상세 결함 리포트를 자동으로 작성해 드립니다.',
+    actionLabel: '결함 리포트 생성하기',
+  },
+  {
+    id: 'defect-report-security',
+    label: '보안성',
+    parentId: 'defect-report',
+    level: 'secondary',
+    description: '보안 취약점과 관련된 자료를 업로드하고 보안성 중심의 결함 리포트를 생성하세요.',
+    actionLabel: '보안성 리포트 생성하기',
+  },
+  {
+    id: 'performance-report',
+    label: '성능평가리포트 생성',
+    level: 'primary',
+    description: '성능 측정 결과를 업로드하면 핵심 지표가 정리된 성능평가 리포트를 만들어 드립니다.',
+    actionLabel: '성능평가 리포트 생성하기',
+  },
+]
+
+export function ProjectManagementPage({ projectId }: ProjectManagementPageProps) {
+  const projectName = useMemo(() => {
+    const searchParams = new URLSearchParams(window.location.search)
+    const name = searchParams.get('name')
+    return name ?? projectId
+  }, [projectId])
+
+  const [activeSectionId, setActiveSectionId] = useState<string>('feature-tc')
+
+  const activeSection = sections.find((section) => section.id === activeSectionId) ?? sections[0]
+
+  return (
+    <div className="project-management-layout">
+      <header className="project-management-header">
+        <div className="project-management-header__content">
+          <p className="project-management-header__eyebrow">프로젝트 관리</p>
+          <h1 className="project-management-header__title">{projectName}</h1>
+          <p className="project-management-header__subtitle">
+            프로젝트별 테스트와 리포트 생성을 한 곳에서 빠르게 관리하세요.
+          </p>
+        </div>
+      </header>
+
+      <div className="project-management-page">
+        <aside className="project-management-sidebar">
+          <div className="project-management-overview">
+            <span className="project-management-overview__label">프로젝트</span>
+            <strong className="project-management-overview__name">{projectName}</strong>
+          </div>
+
+          <nav aria-label="프로젝트 관리 메뉴" className="project-management-menu">
+            <ul className="project-management-menu__list">
+              {sections
+                .filter((section) => section.level === 'primary')
+                .map((section) => {
+                  const childSections = sections.filter((child) => child.parentId === section.id)
+
+                  return (
+                    <li key={section.id} className="project-management-menu__group">
+                      <button
+                        type="button"
+                        className={[
+                          'project-management-menu__item',
+                          'project-management-menu__item--primary',
+                          activeSectionId === section.id ? 'project-management-menu__item--active' : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                        onClick={() => setActiveSectionId(section.id)}
+                      >
+                        <span aria-hidden="true" className="project-management-menu__prefix">
+                          -
+                        </span>
+                        <span className="project-management-menu__label">{section.label}</span>
+                      </button>
+
+                      {childSections.length > 0 && (
+                        <ul className="project-management-menu__sublist">
+                          {childSections.map((childSection) => (
+                            <li key={childSection.id}>
+                              <button
+                                type="button"
+                                className={[
+                                  'project-management-menu__item',
+                                  'project-management-menu__item--secondary',
+                                  activeSectionId === childSection.id
+                                    ? 'project-management-menu__item--active'
+                                    : '',
+                                ]
+                                  .filter(Boolean)
+                                  .join(' ')}
+                                onClick={() => setActiveSectionId(childSection.id)}
+                              >
+                                <span aria-hidden="true" className="project-management-menu__prefix">
+                                  &gt;
+                                </span>
+                                <span className="project-management-menu__label">{childSection.label}</span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </li>
+                  )
+                })}
+            </ul>
+          </nav>
+        </aside>
+
+        <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠">
+          <section className="project-management-section" aria-labelledby={`section-${activeSection.id}`}>
+            <div className="project-management-section__header">
+              <h2 id={`section-${activeSection.id}`} className="project-management-section__title">
+                {activeSection.label}
+              </h2>
+              <p className="project-management-section__description">{activeSection.description}</p>
+            </div>
+
+            <div className="project-management-upload" role="group" aria-labelledby={`section-${activeSection.id}`}>
+              <div className="project-management-upload__dropzone">
+                <input
+                  className="project-management-upload__input"
+                  id={`upload-${activeSection.id}`}
+                  type="file"
+                  multiple
+                />
+                <label htmlFor={`upload-${activeSection.id}`} className="project-management-upload__label">
+                  <span className="project-management-upload__icon" aria-hidden="true">
+                    ⬆
+                  </span>
+                  <span className="project-management-upload__text">
+                    파일을 이곳에 끌어오거나 클릭하여 업로드하세요.
+                  </span>
+                </label>
+              </div>
+              <p className="project-management-upload__helper">
+                지원 형식: PDF, XLSX, CSV, DOCX — 최대 200MB
+              </p>
+            </div>
+
+            <div className="project-management-actions">
+              <button type="button" className="project-management-primary-button">
+                {activeSection.actionLabel}
+              </button>
+              <button type="button" className="project-management-secondary-button">
+                업로드 내역 관리
+              </button>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- redesign the project management view with a full-page layout, prominent header, and content card
- make sidebar menu entries interactive so each section switches contextual upload and action controls
- refresh shared styles to support the new dropzone, button set, and responsive layout refinements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8cbf4b1bc83308716528aa8bc32b5