### PR TITLE
Tighten sidebar hierarchy for defect workflows

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,12 +1,99 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(241, 245, 249, 0.82) 0%, rgba(226, 232, 240, 0.95) 100%);
+}
+
+.app-shell__header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem clamp(1.5rem, 4vw, 3.5rem);
+  background: rgba(15, 23, 42, 0.92);
+  color: white;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(12px);
+}
+
+.app-shell__brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.app-shell__nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.app-shell__link {
+  position: relative;
+  color: rgba(226, 232, 240, 0.9);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.app-shell__link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.45rem;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.65);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.app-shell__link:hover {
+  color: white;
+}
+
+.app-shell__link:hover::after,
+.app-shell__link--active::after {
+  transform: scaleX(1);
+}
+
+.app-shell__link--active {
+  color: white;
+}
+
+.app-shell__main {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: clamp(2rem, 4vw, 4rem) clamp(1.5rem, 4vw, 3.5rem);
+}
+
+.app-shell__footer {
+  padding: 1.5rem clamp(1.5rem, 4vw, 3.5rem);
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.72);
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(16px);
+}
+
 .page {
-  width: min(480px, 100%);
-  padding: 3.5rem 3rem;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: clamp(2.5rem, 4vw, 4rem) clamp(1.75rem, 3vw, 3.5rem);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(12px);
   box-shadow:
-    0 25px 45px rgba(15, 23, 42, 0.15),
-    0 2px 10px rgba(15, 23, 42, 0.08);
+    0 25px 45px rgba(15, 23, 42, 0.12),
+    0 2px 12px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
@@ -15,27 +102,26 @@
 .page__header {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  text-align: center;
+  gap: 0.85rem;
 }
 
 .page__eyebrow {
   display: inline-flex;
-  align-self: center;
+  align-self: flex-start;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #0f172a;
-  background: rgba(148, 163, 184, 0.2);
+  background: rgba(59, 130, 246, 0.12);
 }
 
 .page__title {
   margin: 0;
-  font-size: clamp(2rem, 2.5vw + 1.5rem, 2.6rem);
-  line-height: 1.25;
+  font-size: clamp(2.1rem, 3vw + 1.2rem, 3rem);
+  line-height: 1.2;
   font-weight: 700;
   color: #0f172a;
 }
@@ -718,45 +804,43 @@
 }
 
 .project-management-page {
-  width: min(1200px, 100%);
+  width: min(1180px, 100%);
   min-height: 70vh;
-  display: flex;
-  gap: 2.5rem;
-  padding: 2.5rem 2rem;
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(12px);
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: clamp(1.75rem, 3vw, 3rem);
+  padding: clamp(2rem, 4vw, 3rem);
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.98);
   box-shadow:
-    0 25px 45px rgba(15, 23, 42, 0.15),
-    0 2px 10px rgba(15, 23, 42, 0.08);
+    0 25px 45px rgba(15, 23, 42, 0.1),
+    0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
 .project-management-sidebar {
-  width: 280px;
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  padding-right: 1rem;
-  border-right: 1px solid rgba(148, 163, 184, 0.35);
+  gap: 2rem;
+  padding-right: clamp(0.5rem, 2vw, 1.5rem);
+  border-right: 1px solid rgba(148, 163, 184, 0.3);
 }
 
 .project-management-overview {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
 .project-management-overview__label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #475569;
+  color: #64748b;
 }
 
 .project-management-overview__name {
-  font-size: 1.35rem;
+  font-size: 1.45rem;
   font-weight: 700;
   color: #0f172a;
   word-break: keep-all;
@@ -769,71 +853,256 @@
   padding: 0;
   display: flex;
   flex-direction: column;
+  gap: 0.85rem;
 }
 
 .project-management-menu__sublist {
-  margin-top: 0.75rem;
-  padding-left: 1.5rem;
+  margin-top: 0.85rem;
+  padding-left: 1.25rem;
   gap: 0.75rem;
 }
 
 .project-management-menu__item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  font-size: 1rem;
+  font-size: 0.98rem;
   color: #1f2937;
 }
 
-.project-management-menu__item + .project-management-menu__item {
-  margin-top: 1rem;
-}
-
 .project-management-menu__item--secondary {
-  font-size: 0.95rem;
+  font-size: 0.94rem;
   color: #334155;
 }
 
-.project-management-menu__prefix {
+.project-management-menu__item--group {
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  margin-top: 1rem;
+}
+
+.project-management-menu__group-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 0.4rem 0.9rem 0;
+  background: transparent;
+  border: none;
+  font: inherit;
+  color: #1f2937;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.project-management-menu__group-button:hover,
+.project-management-menu__group-button:focus-visible {
+  color: #2563eb;
+}
+
+.project-management-menu__item--active .project-management-menu__group-button {
+  color: #1d4ed8;
+}
+
+.project-management-menu__chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.project-management-menu__chevron--open {
+  transform: rotate(-135deg);
+}
+
+.project-management-menu__group-header {
+  font-size: 0.85rem;
   font-weight: 700;
-  color: #0f172a;
-  line-height: 1;
-  margin-top: 0.15rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.project-management-menu__sublist--collapsed {
+  display: none;
+}
+
+.project-management-menu__button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.project-management-menu__button:hover,
+.project-management-menu__button:focus-visible {
+  border-color: rgba(59, 130, 246, 0.4);
+  background: rgba(59, 130, 246, 0.08);
+  box-shadow: 0 8px 18px rgba(59, 130, 246, 0.12);
+}
+
+.project-management-menu__indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.6);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.project-management-menu__item--active .project-management-menu__indicator {
+  background: #2563eb;
+  transform: scale(1.25);
+}
+
+.project-management-menu__item--active .project-management-menu__button {
+  border-color: rgba(37, 99, 235, 0.5);
+  background: rgba(59, 130, 246, 0.12);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.16);
 }
 
 .project-management-menu__label {
-  font-weight: 500;
-}
-
-.project-management-menu__group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  font-weight: 600;
 }
 
 .project-management-content {
-  flex: 1;
-  border-radius: 20px;
-  background: rgba(241, 245, 249, 0.65);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.8), rgba(226, 232, 240, 0.9));
   border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  display: flex;
 }
 
-@media (max-width: 960px) {
+.project-management-content__inner {
+  flex: 1;
+  padding: clamp(2rem, 4vw, 3.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.project-management-content__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 620px;
+}
+
+.project-management-content__eyebrow {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.project-management-content__title {
+  margin: 0;
+  font-size: clamp(1.9rem, 2vw + 1.4rem, 2.6rem);
+  line-height: 1.25;
+  color: #0f172a;
+}
+
+.project-management-content__description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #475569;
+}
+
+.project-management-content__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.project-management-content__section-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.project-management-content__helper {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.project-management-content__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.project-management-content__button {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 220px;
+  padding: 0.9rem 2.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #4f46e5);
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-management-content__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.32);
+}
+
+.project-management-content__button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+}
+
+.project-management-content__footnote {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+@media (max-width: 1024px) {
   .project-management-page {
-    flex-direction: column;
-    padding: 2rem 1.5rem;
+    grid-template-columns: 1fr;
+    padding: clamp(1.75rem, 4vw, 2.5rem);
   }
 
   .project-management-sidebar {
-    width: 100%;
     border-right: none;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.3);
     padding-bottom: 1.5rem;
   }
+}
 
-  .project-management-content {
-    width: 100%;
-    min-height: 320px;
+@media (max-width: 720px) {
+  .project-management-menu__button {
+    padding: 0.75rem 0.9rem;
+  }
+
+  .project-management-content__inner {
+    padding: clamp(1.5rem, 6vw, 2.5rem);
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { listen, navigate } from './navigation'
 import { DriveSetupPage } from './pages/DriveSetupPage'
@@ -27,15 +27,35 @@ function App() {
 
   const projectMatch = pathname.match(/^\/projects\/([^/]+)$/)
 
-  if (projectMatch) {
-    return <ProjectManagementPage projectId={decodeURIComponent(projectMatch[1])} />
-  }
+  const pageContent = useMemo(() => {
+    if (projectMatch) {
+      return <ProjectManagementPage projectId={decodeURIComponent(projectMatch[1])} />
+    }
 
-  if (pathname === '/drive') {
-    return <DriveSetupPage />
-  }
+    if (pathname === '/drive') {
+      return <DriveSetupPage />
+    }
 
-  return <LoginPage />
+    return <LoginPage />
+  }, [pathname, projectMatch])
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <div className="app-shell__brand">TTA AI 프로젝트 허브</div>
+        <nav aria-label="주요 메뉴" className="app-shell__nav">
+          <a href="/" className={`app-shell__link${pathname === '/' ? ' app-shell__link--active' : ''}`}>로그인</a>
+          <a href="/drive" className={`app-shell__link${pathname === '/drive' ? ' app-shell__link--active' : ''}`}>
+            Drive 연동
+          </a>
+        </nav>
+      </header>
+
+      <main className="app-shell__main">{pageContent}</main>
+
+      <footer className="app-shell__footer">© {new Date().getFullYear()} TTA AI Platform</footer>
+    </div>
+  )
 }
 
 export default App

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,43 +1,11 @@
 import { useMemo, useState } from 'react'
 import type { ChangeEvent, DragEvent } from 'react'
 
-export type FileType = 'pdf' | 'txt' | 'jpg' | 'csv' | 'html'
-
-interface FileTypeInfo {
-  label: string
-  accept: string[]
-  extensions: string[]
-}
-
-export const FILE_TYPE_OPTIONS: Record<FileType, FileTypeInfo> = {
-  pdf: {
-    label: 'PDF',
-    accept: ['.pdf', 'application/pdf'],
-    extensions: ['pdf'],
-  },
-  txt: {
-    label: 'TXT',
-    accept: ['.txt', 'text/plain'],
-    extensions: ['txt'],
-  },
-  jpg: {
-    label: 'JPG',
-    accept: ['.jpg', '.jpeg', 'image/jpeg'],
-    extensions: ['jpg', 'jpeg'],
-  },
-  csv: {
-    label: 'CSV',
-    accept: ['.csv', 'text/csv'],
-    extensions: ['csv'],
-  },
-  html: {
-    label: 'HTML',
-    accept: ['.html', '.htm', 'text/html'],
-    extensions: ['html', 'htm'],
-  },
-}
-
-export const ALL_FILE_TYPES = Object.keys(FILE_TYPE_OPTIONS) as FileType[]
+import {
+  ALL_FILE_TYPES,
+  FILE_TYPE_OPTIONS,
+  type FileType,
+} from './fileUploaderTypes'
 
 interface FileUploaderProps {
   allowedTypes: FileType[]

--- a/frontend/src/components/ProjectCreationModal.tsx
+++ b/frontend/src/components/ProjectCreationModal.tsx
@@ -4,7 +4,7 @@ import type { FormEvent } from 'react'
 import { getBackendUrl } from '../config'
 import { Modal } from './Modal'
 import { FileUploader } from './FileUploader'
-import type { FileType } from './FileUploader'
+import type { FileType } from './fileUploaderTypes'
 
 interface ProjectCreationModalProps {
   open: boolean

--- a/frontend/src/components/fileUploaderTypes.ts
+++ b/frontend/src/components/fileUploaderTypes.ts
@@ -1,0 +1,37 @@
+export type FileType = 'pdf' | 'txt' | 'jpg' | 'csv' | 'html'
+
+interface FileTypeInfo {
+  label: string
+  accept: string[]
+  extensions: string[]
+}
+
+export const FILE_TYPE_OPTIONS: Record<FileType, FileTypeInfo> = {
+  pdf: {
+    label: 'PDF',
+    accept: ['.pdf', 'application/pdf'],
+    extensions: ['pdf'],
+  },
+  txt: {
+    label: 'TXT',
+    accept: ['.txt', 'text/plain'],
+    extensions: ['txt'],
+  },
+  jpg: {
+    label: 'JPG',
+    accept: ['.jpg', '.jpeg', 'image/jpeg'],
+    extensions: ['jpg', 'jpeg'],
+  },
+  csv: {
+    label: 'CSV',
+    accept: ['.csv', 'text/csv'],
+    extensions: ['csv'],
+  },
+  html: {
+    label: 'HTML',
+    accept: ['.html', '.htm', 'text/html'],
+    extensions: ['html', 'htm'],
+  },
+}
+
+export const ALL_FILE_TYPES = Object.keys(FILE_TYPE_OPTIONS) as FileType[]

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,23 +25,12 @@ a:hover {
 body {
   margin: 0;
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 3rem 1.5rem;
   background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 55%),
     radial-gradient(circle at bottom, rgba(249, 115, 22, 0.25), transparent 55%),
     linear-gradient(160deg, #f8fafc 0%, #e2e8f0 100%);
+  color: inherit;
 }
 
 #root {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
-
-@media (max-width: 640px) {
-  body {
-    padding: 2.5rem 1.25rem;
-  }
+  min-height: 100vh;
 }

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1,4 +1,91 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+
+import { FileUploader } from '../components/FileUploader'
+import {
+  ALL_FILE_TYPES,
+  type FileType,
+} from '../components/fileUploaderTypes'
+
+type MenuItemId = 'feature-tc' | 'defect-report' | 'security-report' | 'performance-report'
+type MenuGroupId = 'defect-group'
+
+type PrimaryMenuEntry =
+  | {
+      type: 'item'
+      itemId: MenuItemId
+    }
+  | {
+      type: 'group'
+      id: MenuGroupId
+      label: string
+      itemIds: MenuItemId[]
+    }
+
+interface MenuItemContent {
+  id: MenuItemId
+  label: string
+  eyebrow: string
+  title: string
+  description: string
+  helper: string
+  buttonLabel: string
+  allowedTypes: FileType[]
+}
+
+const MENU_ITEMS: MenuItemContent[] = [
+  {
+    id: 'feature-tc',
+    label: '기능 및 TC 생성',
+    eyebrow: '기능 & 테스트',
+    title: '요구사항에서 기능과 테스트 케이스 생성',
+    description:
+      '요구사항 명세나 기획 문서를 업로드하면 AI가 기능 정의서와 테스트 케이스 초안을 자동으로 제안합니다.',
+    helper: 'PDF, TXT, CSV 등 요구사항 관련 문서를 업로드해 주세요. 여러 파일을 동시에 첨부할 수 있습니다.',
+    buttonLabel: '기능 및 TC 생성하기',
+    allowedTypes: ALL_FILE_TYPES,
+  },
+  {
+    id: 'defect-report',
+    label: '결함 리포트',
+    eyebrow: '결함 리포트',
+    title: '결함 리포트 초안 만들기',
+    description:
+      '시험 결과와 로그 파일을 업로드하면 결함 리포트 초안을 빠르게 구성할 수 있습니다.',
+    helper: '테스트 로그, 정리된 표, 스크린샷 등 결함 관련 증적 자료를 첨부해 주세요.',
+    buttonLabel: '결함 리포트 생성하기',
+    allowedTypes: ['pdf', 'txt', 'csv', 'jpg'],
+  },
+  {
+    id: 'security-report',
+    label: '보안성 리포트',
+    eyebrow: '보안성 분석',
+    title: '보안성 분석 리포트 생성',
+    description:
+      '보안 점검 결과와 취약점 목록을 업로드하면 AI가 요약과 개선 권고안을 정리합니다.',
+    helper: '취약점 점검표, 분석 보고서, 스크린샷 등을 첨부해 주세요.',
+    buttonLabel: '보안성 리포트 생성하기',
+    allowedTypes: ['pdf', 'txt', 'csv'],
+  },
+  {
+    id: 'performance-report',
+    label: '성능 평가 리포트',
+    eyebrow: '성능 평가',
+    title: '성능 평가 리포트 완성하기',
+    description:
+      '벤치마크 결과나 모니터링 데이터를 업로드하면 성능 분석 리포트를 구조화해 드립니다.',
+    helper: '성능 측정 결과 표, CSV 데이터, 스크린샷 등을 업로드해 주세요.',
+    buttonLabel: '성능평가 리포트 생성하기',
+    allowedTypes: ['pdf', 'csv', 'txt'],
+  },
+]
+
+const MENU_ITEM_IDS = MENU_ITEMS.map((item) => item.id)
+
+const PRIMARY_MENU: PrimaryMenuEntry[] = [
+  { type: 'item', itemId: 'feature-tc' },
+  { type: 'group', id: 'defect-group', label: '결함리포트 생성', itemIds: ['defect-report', 'security-report'] },
+  { type: 'item', itemId: 'performance-report' },
+]
 
 interface ProjectManagementPageProps {
   projectId: string
@@ -11,6 +98,33 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
     return name ?? projectId
   }, [projectId])
 
+  const [activeItem, setActiveItem] = useState<MenuItemId>('feature-tc')
+  const [openGroups, setOpenGroups] = useState<Record<MenuGroupId, boolean>>({
+    'defect-group': true,
+  })
+  const [filesByItem, setFilesByItem] = useState<Record<MenuItemId, File[]>>(() => {
+    return MENU_ITEM_IDS.reduce((acc, id) => {
+      acc[id as MenuItemId] = []
+      return acc
+    }, {} as Record<MenuItemId, File[]>)
+  })
+
+  const activeContent = MENU_ITEMS.find((item) => item.id === activeItem) ?? MENU_ITEMS[0]
+
+  const handleChangeFiles = (id: MenuItemId, nextFiles: File[]) => {
+    setFilesByItem((prev) => ({
+      ...prev,
+      [id]: nextFiles,
+    }))
+  }
+
+  const handleToggleGroup = (groupId: MenuGroupId) => {
+    setOpenGroups((prev) => ({
+      ...prev,
+      [groupId]: !prev[groupId],
+    }))
+  }
+
   return (
     <div className="project-management-page">
       <aside className="project-management-sidebar">
@@ -21,45 +135,128 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
 
         <nav aria-label="프로젝트 관리 메뉴" className="project-management-menu">
           <ul className="project-management-menu__list">
-            <li className="project-management-menu__item project-management-menu__item--primary">
-              <span aria-hidden="true" className="project-management-menu__prefix">
-                -
-              </span>
-              <span className="project-management-menu__label">기능 및 TC 생성 메뉴</span>
-            </li>
-            <li className="project-management-menu__item project-management-menu__item--primary">
-              <span aria-hidden="true" className="project-management-menu__prefix">
-                -
-              </span>
-              <div className="project-management-menu__group">
-                <span className="project-management-menu__label">결함리포트 생성</span>
-                <ul className="project-management-menu__sublist">
-                  <li className="project-management-menu__item project-management-menu__item--secondary">
-                    <span aria-hidden="true" className="project-management-menu__prefix">
-                      &gt;
-                    </span>
-                    <span className="project-management-menu__label">결함</span>
+            {PRIMARY_MENU.map((entry) => {
+              if (entry.type === 'item') {
+                const item = MENU_ITEMS.find((menuItem) => menuItem.id === entry.itemId)
+                if (!item) {
+                  return null
+                }
+
+                const isActive = activeItem === item.id
+
+                return (
+                  <li
+                    key={item.id}
+                    className={`project-management-menu__item project-management-menu__item--primary${
+                      isActive ? ' project-management-menu__item--active' : ''
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      className="project-management-menu__button"
+                      onClick={() => setActiveItem(item.id)}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      <span className="project-management-menu__indicator" aria-hidden="true" />
+                      <span className="project-management-menu__label">{item.label}</span>
+                    </button>
                   </li>
-                  <li className="project-management-menu__item project-management-menu__item--secondary">
-                    <span aria-hidden="true" className="project-management-menu__prefix">
-                      &gt;
-                    </span>
-                    <span className="project-management-menu__label">보안성</span>
-                  </li>
-                </ul>
-              </div>
-            </li>
-            <li className="project-management-menu__item project-management-menu__item--primary">
-              <span aria-hidden="true" className="project-management-menu__prefix">
-                -
-              </span>
-              <span className="project-management-menu__label">성능평가리포트 생성</span>
-            </li>
+                )
+              }
+
+              const isOpen = openGroups[entry.id]
+              const groupActive = entry.itemIds.includes(activeItem)
+
+              return (
+                <li
+                  key={entry.id}
+                  className={`project-management-menu__item project-management-menu__item--primary project-management-menu__item--group${
+                    groupActive ? ' project-management-menu__item--active' : ''
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="project-management-menu__group-button"
+                    onClick={() => handleToggleGroup(entry.id)}
+                    aria-expanded={isOpen}
+                  >
+                    <span className="project-management-menu__label">{entry.label}</span>
+                    <span
+                      className={`project-management-menu__chevron${isOpen ? ' project-management-menu__chevron--open' : ''}`}
+                      aria-hidden="true"
+                    />
+                  </button>
+                  <ul
+                    className={`project-management-menu__sublist${
+                      isOpen ? '' : ' project-management-menu__sublist--collapsed'
+                    }`}
+                    hidden={!isOpen}
+                  >
+                    {entry.itemIds.map((itemId) => {
+                      const item = MENU_ITEMS.find((menuItem) => menuItem.id === itemId)
+                      if (!item) {
+                        return null
+                      }
+
+                      const isActive = activeItem === item.id
+
+                      return (
+                        <li
+                          key={item.id}
+                          className={`project-management-menu__item project-management-menu__item--secondary${
+                            isActive ? ' project-management-menu__item--active' : ''
+                          }`}
+                        >
+                          <button
+                            type="button"
+                            className="project-management-menu__button"
+                            onClick={() => setActiveItem(item.id)}
+                            aria-current={isActive ? 'page' : undefined}
+                          >
+                            <span className="project-management-menu__indicator" aria-hidden="true" />
+                            <span className="project-management-menu__label">{item.label}</span>
+                          </button>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </li>
+              )
+            })}
           </ul>
         </nav>
       </aside>
 
-      <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠" />
+      <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠">
+        <div className="project-management-content__inner">
+          <div className="project-management-content__header">
+            <span className="project-management-content__eyebrow">{activeContent.eyebrow}</span>
+            <h1 className="project-management-content__title">{activeContent.title}</h1>
+            <p className="project-management-content__description">{activeContent.description}</p>
+          </div>
+
+          <section aria-labelledby="upload-section" className="project-management-content__section">
+            <h2 id="upload-section" className="project-management-content__section-title">
+              자료 업로드
+            </h2>
+            <p className="project-management-content__helper">{activeContent.helper}</p>
+            <FileUploader
+              allowedTypes={activeContent.allowedTypes}
+              files={filesByItem[activeContent.id]}
+              onChange={(nextFiles) => handleChangeFiles(activeContent.id, nextFiles)}
+            />
+          </section>
+
+          <div className="project-management-content__actions">
+            <button type="button" className="project-management-content__button">
+              {activeContent.buttonLabel}
+            </button>
+            <p className="project-management-content__footnote">
+              업로드된 문서는 프로젝트 드라이브에 안전하게 보관되며, 생성된 결과는 별도의 탭에서 확인할 수 있습니다.
+            </p>
+          </div>
+        </div>
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- restructure the project management sidebar to use a dedicated defect report group with toggleable sub-navigation
- add styling for expandable sidebar groups, including chevrons and collapsed sublists, to match the desired hierarchy
- align performance report labels with the refreshed navigation copy

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e614286c8330864dac64256d0b0d