### PR TITLE
Refine project navigation menu

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -857,9 +857,9 @@
 }
 
 .project-management-menu__sublist {
-  margin-top: 0.85rem;
-  padding-left: 1.25rem;
-  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.35rem 0.4rem 0.35rem;
+  gap: 0.65rem;
 }
 
 .project-management-menu__item {
@@ -872,59 +872,33 @@
   color: #334155;
 }
 
+.project-management-menu__item--primary {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.72);
+  padding: 0.3rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
 .project-management-menu__item--group {
-  padding-top: 1rem;
-  border-top: 1px solid rgba(148, 163, 184, 0.3);
-  margin-top: 1rem;
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
 }
 
-.project-management-menu__group-button {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.9rem 0.4rem 0.9rem 0;
-  background: transparent;
-  border: none;
-  font: inherit;
-  color: #1f2937;
-  cursor: pointer;
-  transition: color 0.2s ease;
+.project-management-menu__item--group .project-management-menu__sublist {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.project-management-menu__group-button:hover,
-.project-management-menu__group-button:focus-visible {
-  color: #2563eb;
-}
-
-.project-management-menu__item--active .project-management-menu__group-button {
-  color: #1d4ed8;
-}
-
-.project-management-menu__chevron {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
-  transition: transform 0.2s ease;
-}
-
-.project-management-menu__chevron--open {
-  transform: rotate(-135deg);
-}
-
-.project-management-menu__group-header {
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: #475569;
-}
-
-.project-management-menu__sublist--collapsed {
-  display: none;
+.project-management-menu__item--expanded.project-management-menu__item--primary,
+.project-management-menu__item--active.project-management-menu__item--primary {
+  border-color: rgba(37, 99, 235, 0.45);
+  background: rgba(59, 130, 246, 0.14);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.14);
 }
 
 .project-management-menu__button {
@@ -943,6 +917,32 @@
   transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.project-management-menu__button--group {
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.project-management-menu__button-leading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.project-management-menu__item--secondary .project-management-menu__button {
+  padding: 0.75rem 0.85rem;
+}
+
+.project-management-menu__item--secondary .project-management-menu__button-leading {
+  width: 1.75rem;
+  height: 1.75rem;
+  background: rgba(148, 163, 184, 0.12);
+}
+
 .project-management-menu__button:hover,
 .project-management-menu__button:focus-visible {
   border-color: rgba(59, 130, 246, 0.4);
@@ -950,27 +950,57 @@
   box-shadow: 0 8px 18px rgba(59, 130, 246, 0.12);
 }
 
+.project-management-menu__item--active .project-management-menu__button,
+.project-management-menu__item--expanded .project-management-menu__button {
+  border-color: rgba(37, 99, 235, 0.45);
+  background: rgba(59, 130, 246, 0.12);
+  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.14);
+}
+
 .project-management-menu__indicator {
-  width: 10px;
-  height: 10px;
+  width: 0.55rem;
+  height: 0.55rem;
   border-radius: 50%;
-  background: rgba(148, 163, 184, 0.6);
+  background: rgba(148, 163, 184, 0.65);
   transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.project-management-menu__item--active .project-management-menu__button-leading {
+  background: rgba(37, 99, 235, 0.2);
+  transform: scale(1.05);
 }
 
 .project-management-menu__item--active .project-management-menu__indicator {
   background: #2563eb;
-  transform: scale(1.25);
-}
-
-.project-management-menu__item--active .project-management-menu__button {
-  border-color: rgba(37, 99, 235, 0.5);
-  background: rgba(59, 130, 246, 0.12);
-  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.16);
+  transform: scale(1.1);
 }
 
 .project-management-menu__label {
+  flex: 1;
+  min-width: 0;
   font-weight: 600;
+}
+
+.project-management-menu__item--secondary .project-management-menu__label {
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.project-management-menu__chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.project-management-menu__chevron--open {
+  transform: rotate(-135deg);
+}
+
+.project-management-menu__sublist--collapsed {
+  display: none;
 }
 
 .project-management-content {

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -118,11 +118,18 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
     }))
   }
 
-  const handleToggleGroup = (groupId: MenuGroupId) => {
+  const handleSelectGroup = (entry: Extract<PrimaryMenuEntry, { type: 'group' }>) => {
+    const wasOpen = !!openGroups[entry.id]
+    const nextOpen = !wasOpen
+
     setOpenGroups((prev) => ({
       ...prev,
-      [groupId]: !prev[groupId],
+      [entry.id]: nextOpen,
     }))
+
+    if (nextOpen && !entry.itemIds.includes(activeItem)) {
+      setActiveItem(entry.itemIds[0])
+    }
   }
 
   return (
@@ -157,7 +164,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                       onClick={() => setActiveItem(item.id)}
                       aria-current={isActive ? 'page' : undefined}
                     >
-                      <span className="project-management-menu__indicator" aria-hidden="true" />
+                      <span className="project-management-menu__button-leading" aria-hidden="true">
+                        <span className="project-management-menu__indicator" />
+                      </span>
                       <span className="project-management-menu__label">{item.label}</span>
                     </button>
                   </li>
@@ -172,14 +181,17 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                   key={entry.id}
                   className={`project-management-menu__item project-management-menu__item--primary project-management-menu__item--group${
                     groupActive ? ' project-management-menu__item--active' : ''
-                  }`}
+                  }${isOpen ? ' project-management-menu__item--expanded' : ''}`}
                 >
                   <button
                     type="button"
-                    className="project-management-menu__group-button"
-                    onClick={() => handleToggleGroup(entry.id)}
+                    className="project-management-menu__button project-management-menu__button--group"
+                    onClick={() => handleSelectGroup(entry)}
                     aria-expanded={isOpen}
                   >
+                    <span className="project-management-menu__button-leading" aria-hidden="true">
+                      <span className="project-management-menu__indicator" />
+                    </span>
                     <span className="project-management-menu__label">{entry.label}</span>
                     <span
                       className={`project-management-menu__chevron${isOpen ? ' project-management-menu__chevron--open' : ''}`}
@@ -213,7 +225,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                             onClick={() => setActiveItem(item.id)}
                             aria-current={isActive ? 'page' : undefined}
                           >
-                            <span className="project-management-menu__indicator" aria-hidden="true" />
+                            <span className="project-management-menu__button-leading" aria-hidden="true">
+                              <span className="project-management-menu__indicator" />
+                            </span>
                             <span className="project-management-menu__label">{item.label}</span>
                           </button>
                         </li>


### PR DESCRIPTION
## Summary
- unify the project management sidebar so grouped menu entries use the same button layout as standalone items
- update styling for primary and secondary items to open the defect group submenu on selection and keep indicators aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ea92819083308973cebbfc8731fb