### PR TITLE
Add CSV generation workflow for project menus

### DIFF
--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -1,13 +1,101 @@
 from __future__ import annotations
 
+import csv
+import io
+import random
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from ..container import drive_service
 
 router = APIRouter()
+
+
+_SAMPLE_REPORTS: Dict[str, List[Dict[str, Any]]] = {
+    "feature-tc": [
+        {
+            "filename": "feature_tc_summary.csv",
+            "rows": [
+                ["기능", "테스트 케이스 ID", "우선순위", "작성 상태"],
+                ["사용자 로그인", "TC-FT-001", "높음", "초안"],
+                ["회원가입", "TC-FT-002", "중간", "검토 중"],
+                ["비밀번호 재설정", "TC-FT-003", "높음", "초안"],
+            ],
+        },
+        {
+            "filename": "feature_tc_traceability.csv",
+            "rows": [
+                ["요구사항 ID", "기능", "테스트 케이스"],
+                ["REQ-101", "사용자 로그인", "TC-FT-011"],
+                ["REQ-102", "2단계 인증", "TC-FT-012"],
+                ["REQ-103", "계정 잠금", "TC-FT-013"],
+            ],
+        },
+    ],
+    "defect-report": [
+        {
+            "filename": "defect_overview.csv",
+            "rows": [
+                ["결함 ID", "심각도", "모듈", "현황"],
+                ["BUG-210", "중대", "결제", "재현됨"],
+                ["BUG-214", "치명", "주문", "조치 필요"],
+                ["BUG-219", "경미", "알림", "검토 중"],
+            ],
+        },
+        {
+            "filename": "defect_root_cause.csv",
+            "rows": [
+                ["결함 ID", "원인", "개선 계획"],
+                ["BUG-301", "API 응답 지연", "캐시 전략 개선"],
+                ["BUG-304", "권한 검증 누락", "인증 미들웨어 보강"],
+                ["BUG-308", "입력 검증 부족", "프론트 검증 추가"],
+            ],
+        },
+    ],
+    "security-report": [
+        {
+            "filename": "security_findings.csv",
+            "rows": [
+                ["취약점 ID", "위험도", "카테고리", "조치 현황"],
+                ["SEC-110", "높음", "인증", "완료"],
+                ["SEC-118", "중간", "데이터 암호화", "진행 중"],
+                ["SEC-124", "중간", "로그 분석", "미착수"],
+            ],
+        },
+        {
+            "filename": "security_controls.csv",
+            "rows": [
+                ["통제 항목", "상태", "담당자"],
+                ["계정 잠금 정책", "적용", "김보안"],
+                ["접근 로그 모니터링", "미적용", "이감사"],
+                ["취약점 정기 점검", "진행 중", "박분석"],
+            ],
+        },
+    ],
+    "performance-report": [
+        {
+            "filename": "performance_summary.csv",
+            "rows": [
+                ["시나리오", "TPS", "평균 응답시간(ms)", "성공률"],
+                ["로그인", "180", "230", "99.1%"],
+                ["장바구니", "120", "340", "98.4%"],
+                ["결제", "75", "410", "96.8%"],
+            ],
+        },
+        {
+            "filename": "performance_trend.csv",
+            "rows": [
+                ["측정 구간", "CPU 사용률(%)", "메모리 사용량(MB)"],
+                ["00:00-00:15", "45", "612"],
+                ["00:15-00:30", "51", "648"],
+                ["00:30-00:45", "63", "712"],
+            ],
+        },
+    ],
+}
 
 
 @router.post("/drive/gs/setup")
@@ -42,3 +130,48 @@ async def create_drive_project(
         files=files,
         google_id=google_id,
     )
+
+
+@router.post("/drive/projects/{project_id}/generate")
+async def generate_project_asset(
+    project_id: str,
+    menu_id: str = Form(..., description="생성할 메뉴 ID"),
+    files: Optional[List[UploadFile]] = File(None),
+) -> StreamingResponse:
+    sample_options = _SAMPLE_REPORTS.get(menu_id)
+    if not sample_options:
+        raise HTTPException(status_code=404, detail="지원하지 않는 생성 메뉴입니다.")
+
+    uploads = files or []
+    if not uploads:
+        raise HTTPException(status_code=422, detail="업로드된 자료가 없습니다. 파일을 추가해 주세요.")
+
+    # FastAPI는 업로드 스트림을 자동으로 정리하지만, 명시적으로 읽어
+    # 업로드 완료를 기다리도록 한다.
+    for upload in uploads:
+        try:
+            await upload.read()
+        finally:
+            await upload.close()
+
+    selection = random.choice(sample_options)
+    rows = selection.get("rows", [])
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    for row in rows:
+        writer.writerow(row)
+
+    buffer.seek(0)
+    encoded = buffer.getvalue().encode("utf-8-sig")
+    stream = io.BytesIO(encoded)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    filename = selection.get("filename", "report.csv")
+    generated_name = f"{project_id}_{timestamp}_{filename}"
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="{generated_name}"',
+        "Cache-Control": "no-store",
+    }
+
+    return StreamingResponse(stream, media_type="text/csv", headers=headers)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -621,6 +621,14 @@
   background: rgba(219, 234, 254, 0.4);
 }
 
+.file-uploader__dropzone--disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  border-color: rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.6);
+  box-shadow: none;
+}
+
 .file-uploader__input {
   position: absolute;
   inset: 0;
@@ -693,6 +701,13 @@
 .file-uploader__remove:hover {
   background: rgba(239, 68, 68, 0.2);
   transform: translateY(-1px);
+}
+
+.file-uploader__remove:disabled {
+  background: rgba(148, 163, 184, 0.15);
+  color: rgba(100, 116, 139, 0.95);
+  cursor: not-allowed;
+  transform: none;
 }
 
 .drive-projects__list {
@@ -1107,10 +1122,92 @@
   box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
 }
 
+.project-management-content__button:disabled,
+.project-management-content__button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+  transform: none;
+}
+
 .project-management-content__footnote {
   margin: 0;
   font-size: 0.9rem;
   color: #64748b;
+}
+
+.project-management-content__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.project-management-content__status--loading {
+  color: #2563eb;
+}
+
+.project-management-content__status--loading::before {
+  content: '';
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 2px solid rgba(37, 99, 235, 0.3);
+  border-top-color: #2563eb;
+  animation: project-management-spin 0.75s linear infinite;
+}
+
+.project-management-content__status--error {
+  color: #b91c1c;
+}
+
+.project-management-content__status--error::before {
+  content: '⚠️';
+  font-size: 1rem;
+}
+
+.project-management-content__result {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1.35rem 1.5rem;
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  background: rgba(59, 130, 246, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.project-management-content__download {
+  text-decoration: none;
+}
+
+.project-management-content__secondary {
+  align-self: flex-start;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: white;
+  color: #334155;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-management-content__secondary:hover {
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #2563eb;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.14);
+}
+
+@keyframes project-management-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -11,6 +11,7 @@ interface FileUploaderProps {
   allowedTypes: FileType[]
   files: File[]
   onChange: (files: File[]) => void
+  disabled?: boolean
 }
 
 function formatBytes(bytes: number): string {
@@ -28,7 +29,7 @@ function createFileKey(file: File) {
   return `${file.name}-${file.size}-${file.lastModified}`
 }
 
-export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProps) {
+export function FileUploader({ allowedTypes, files, onChange, disabled = false }: FileUploaderProps) {
   const [isDragging, setIsDragging] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -43,6 +44,10 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   }, [activeTypes])
 
   const handleDragOver = (event: DragEvent<HTMLLabelElement>) => {
+    if (disabled) {
+      return
+    }
+
     event.preventDefault()
     if (!isDragging) {
       setIsDragging(true)
@@ -50,6 +55,10 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   }
 
   const handleDragLeave = (event: DragEvent<HTMLLabelElement>) => {
+    if (disabled) {
+      return
+    }
+
     event.preventDefault()
     if (isDragging) {
       setIsDragging(false)
@@ -57,6 +66,10 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   }
 
   const addFiles = (incoming: File[]) => {
+    if (disabled) {
+      return
+    }
+
     if (incoming.length === 0) {
       return
     }
@@ -98,6 +111,10 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   }
 
   const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
+    if (disabled) {
+      return
+    }
+
     event.preventDefault()
     setIsDragging(false)
     const droppedFiles = Array.from(event.dataTransfer?.files ?? [])
@@ -105,12 +122,21 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   }
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (disabled) {
+      event.target.value = ''
+      return
+    }
+
     const selected = Array.from(event.target.files ?? [])
     addFiles(selected)
     event.target.value = ''
   }
 
   const handleRemove = (index: number) => {
+    if (disabled) {
+      return
+    }
+
     const nextFiles = files.filter((_, currentIndex) => currentIndex !== index)
     onChange(nextFiles)
   }
@@ -118,7 +144,9 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
   return (
     <div className="file-uploader">
       <label
-        className={`file-uploader__dropzone${isDragging ? ' file-uploader__dropzone--active' : ''}`}
+        className={`file-uploader__dropzone${
+          isDragging ? ' file-uploader__dropzone--active' : ''
+        }${disabled ? ' file-uploader__dropzone--disabled' : ''}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -129,6 +157,7 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
           accept={acceptValue}
           multiple
           onChange={handleInputChange}
+          disabled={disabled}
         />
         <div className="file-uploader__prompt">
           <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
@@ -151,6 +180,7 @@ export function FileUploader({ allowedTypes, files, onChange }: FileUploaderProp
                 className="file-uploader__remove"
                 onClick={() => handleRemove(index)}
                 aria-label={`${file.name} 삭제`}
+                disabled={disabled}
               >
                 삭제
               </button>


### PR DESCRIPTION
## Summary
- add backend endpoint that returns sample CSV files for each project menu request
- wire the project management page to upload files, show loading/error states, and surface CSV downloads
- enhance the file uploader and styles to support disabled/loading/result presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8efd44b2c8330adf9cc0493e564c7