### PR TITLE
Integrate OpenAI CSV generation for project assets

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,6 +19,8 @@ class Settings:
     redirect_uri: str
     frontend_redirect_url: str
     tokens_path: Path
+    openai_api_key: str
+    openai_model: str
 
     @property
     def frontend_origin(self) -> str:
@@ -42,4 +44,6 @@ def load_settings() -> Settings:
         redirect_uri=os.getenv("GOOGLE_REDIRECT_URI", ""),
         frontend_redirect_url=os.getenv("FRONTEND_REDIRECT_URL", "http://localhost:5173/"),
         tokens_path=Path(tokens_env) if tokens_env else default_tokens_path,
+        openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+        openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
     )

--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .config import load_settings
+from .services.ai_generation import AIGenerationService
 from .services.google_drive import GoogleDriveService
 from .services.oauth import GoogleOAuthService
 from .token_store import TokenStorage
@@ -12,3 +13,4 @@ token_storage = TokenStorage(settings.tokens_path)
 oauth_service = GoogleOAuthService(settings, token_storage)
 
 drive_service = GoogleDriveService(settings, token_storage, oauth_service)
+ai_generation_service = AIGenerationService(settings)

--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -1,101 +1,14 @@
 from __future__ import annotations
 
-import csv
 import io
-import random
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from ..container import drive_service
+from ..container import ai_generation_service, drive_service
 
 router = APIRouter()
-
-
-_SAMPLE_REPORTS: Dict[str, List[Dict[str, Any]]] = {
-    "feature-tc": [
-        {
-            "filename": "feature_tc_summary.csv",
-            "rows": [
-                ["기능", "테스트 케이스 ID", "우선순위", "작성 상태"],
-                ["사용자 로그인", "TC-FT-001", "높음", "초안"],
-                ["회원가입", "TC-FT-002", "중간", "검토 중"],
-                ["비밀번호 재설정", "TC-FT-003", "높음", "초안"],
-            ],
-        },
-        {
-            "filename": "feature_tc_traceability.csv",
-            "rows": [
-                ["요구사항 ID", "기능", "테스트 케이스"],
-                ["REQ-101", "사용자 로그인", "TC-FT-011"],
-                ["REQ-102", "2단계 인증", "TC-FT-012"],
-                ["REQ-103", "계정 잠금", "TC-FT-013"],
-            ],
-        },
-    ],
-    "defect-report": [
-        {
-            "filename": "defect_overview.csv",
-            "rows": [
-                ["결함 ID", "심각도", "모듈", "현황"],
-                ["BUG-210", "중대", "결제", "재현됨"],
-                ["BUG-214", "치명", "주문", "조치 필요"],
-                ["BUG-219", "경미", "알림", "검토 중"],
-            ],
-        },
-        {
-            "filename": "defect_root_cause.csv",
-            "rows": [
-                ["결함 ID", "원인", "개선 계획"],
-                ["BUG-301", "API 응답 지연", "캐시 전략 개선"],
-                ["BUG-304", "권한 검증 누락", "인증 미들웨어 보강"],
-                ["BUG-308", "입력 검증 부족", "프론트 검증 추가"],
-            ],
-        },
-    ],
-    "security-report": [
-        {
-            "filename": "security_findings.csv",
-            "rows": [
-                ["취약점 ID", "위험도", "카테고리", "조치 현황"],
-                ["SEC-110", "높음", "인증", "완료"],
-                ["SEC-118", "중간", "데이터 암호화", "진행 중"],
-                ["SEC-124", "중간", "로그 분석", "미착수"],
-            ],
-        },
-        {
-            "filename": "security_controls.csv",
-            "rows": [
-                ["통제 항목", "상태", "담당자"],
-                ["계정 잠금 정책", "적용", "김보안"],
-                ["접근 로그 모니터링", "미적용", "이감사"],
-                ["취약점 정기 점검", "진행 중", "박분석"],
-            ],
-        },
-    ],
-    "performance-report": [
-        {
-            "filename": "performance_summary.csv",
-            "rows": [
-                ["시나리오", "TPS", "평균 응답시간(ms)", "성공률"],
-                ["로그인", "180", "230", "99.1%"],
-                ["장바구니", "120", "340", "98.4%"],
-                ["결제", "75", "410", "96.8%"],
-            ],
-        },
-        {
-            "filename": "performance_trend.csv",
-            "rows": [
-                ["측정 구간", "CPU 사용률(%)", "메모리 사용량(MB)"],
-                ["00:00-00:15", "45", "612"],
-                ["00:15-00:30", "51", "648"],
-                ["00:30-00:45", "63", "712"],
-            ],
-        },
-    ],
-}
 
 
 @router.post("/drive/gs/setup")
@@ -138,40 +51,12 @@ async def generate_project_asset(
     menu_id: str = Form(..., description="생성할 메뉴 ID"),
     files: Optional[List[UploadFile]] = File(None),
 ) -> StreamingResponse:
-    sample_options = _SAMPLE_REPORTS.get(menu_id)
-    if not sample_options:
-        raise HTTPException(status_code=404, detail="지원하지 않는 생성 메뉴입니다.")
-
     uploads = files or []
-    if not uploads:
-        raise HTTPException(status_code=422, detail="업로드된 자료가 없습니다. 파일을 추가해 주세요.")
-
-    # FastAPI는 업로드 스트림을 자동으로 정리하지만, 명시적으로 읽어
-    # 업로드 완료를 기다리도록 한다.
-    for upload in uploads:
-        try:
-            await upload.read()
-        finally:
-            await upload.close()
-
-    selection = random.choice(sample_options)
-    rows = selection.get("rows", [])
-    buffer = io.StringIO()
-    writer = csv.writer(buffer)
-    for row in rows:
-        writer.writerow(row)
-
-    buffer.seek(0)
-    encoded = buffer.getvalue().encode("utf-8-sig")
-    stream = io.BytesIO(encoded)
-
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    filename = selection.get("filename", "report.csv")
-    generated_name = f"{project_id}_{timestamp}_{filename}"
+    result = await ai_generation_service.generate_csv(project_id=project_id, menu_id=menu_id, uploads=uploads)
 
     headers = {
-        "Content-Disposition": f'attachment; filename="{generated_name}"',
+        "Content-Disposition": f'attachment; filename="{result.filename}"',
         "Cache-Control": "no-store",
     }
 
-    return StreamingResponse(stream, media_type="text/csv", headers=headers)
+    return StreamingResponse(io.BytesIO(result.content), media_type="text/csv", headers=headers)

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Tuple
+
+from fastapi import HTTPException, UploadFile
+from openai import APIError, OpenAI
+
+from ..config import Settings
+
+_MAX_PREVIEW_CHARS = 6000
+_BASE64_PREFIX = "(base64 인코딩) "
+
+
+@dataclass
+class GeneratedCsv:
+    filename: str
+    content: bytes
+
+
+_PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
+    "feature-tc": {
+        "system": "당신은 소프트웨어 QA 리드입니다. 업로드된 요구사항을 읽고 기능 정의와 테스트 케이스를 구조화된 CSV로 제안하세요.",
+        "instruction": (
+            "요구사항 자료를 참고하여 기능과 테스트 케이스 개요를 작성하세요. "
+            "다음 열을 포함한 CSV를 생성합니다: 기능명, 테스트 케이스 ID, 목적, 우선순위, 비고. "
+            "ID는 FC-001과 같은 형식을 따르도록 합니다."
+        ),
+    },
+    "defect-report": {
+        "system": "당신은 QA 분석가입니다. 업로드된 테스트 로그와 증적 자료를 바탕으로 결함 요약을 작성합니다.",
+        "instruction": (
+            "자료를 분석해 주요 결함을 요약한 CSV를 작성하세요. 열은 결함 ID, 심각도, 발생 모듈, 현상 요약, 제안 조치입니다. "
+            "결함 ID는 BUG-001 형식을 사용하고, 심각도는 치명/중대/보통/경미 중 하나로 표기합니다."
+        ),
+    },
+    "security-report": {
+        "system": "당신은 보안 컨설턴트입니다. 업로드된 보안 점검 결과를 요약한 리포트를 만듭니다.",
+        "instruction": (
+            "자료를 바탕으로 취약점을 정리한 CSV를 작성하세요. 열은 취약점 ID, 위험도, 영향 영역, 발견 내용, 권장 조치입니다. "
+            "위험도는 높음/중간/낮음 중 하나를 사용합니다."
+        ),
+    },
+    "performance-report": {
+        "system": "당신은 성능 엔지니어입니다. 업로드된 성능 측정 자료를 분석하여 결과를 요약합니다.",
+        "instruction": (
+            "자료를 분석하여 주요 시나리오의 성능을 정리한 CSV를 작성하세요. 열은 시나리오, 평균 응답(ms), 처리량(TPS), 자원 사용 요약, 개선 제안입니다."
+        ),
+    },
+}
+
+
+class AIGenerationService:
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        self._client: OpenAI | None = None
+
+    def _get_client(self) -> OpenAI:
+        if self._client is None:
+            api_key = self._settings.openai_api_key
+            if not api_key:
+                raise HTTPException(status_code=500, detail="OpenAI API 키가 설정되어 있지 않습니다.")
+            self._client = OpenAI(api_key=api_key)
+        return self._client
+
+    @staticmethod
+    def _preview_from_uploads(uploads: Iterable[Tuple[str, bytes]]) -> str:
+        sections: List[str] = []
+        for name, raw in uploads:
+            text: str
+            prefix = ""
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                try:
+                    text = raw.decode("cp949")
+                except UnicodeDecodeError:
+                    text = base64.b64encode(raw).decode("ascii")
+                    prefix = _BASE64_PREFIX
+
+            if len(text) > _MAX_PREVIEW_CHARS:
+                text = text[:_MAX_PREVIEW_CHARS] + "\n... (이후 내용 생략)"
+
+            sections.append(f"### 파일: {name}\n{prefix}{text}")
+
+        return "\n\n".join(sections)
+
+    @staticmethod
+    def _sanitize_csv(text: str) -> str:
+        cleaned = text.strip()
+        fence_match = re.search(r"```(?:csv)?\s*(.*?)```", cleaned, re.DOTALL | re.IGNORECASE)
+        if fence_match:
+            cleaned = fence_match.group(1).strip()
+        return cleaned
+
+    async def generate_csv(self, project_id: str, menu_id: str, uploads: List[UploadFile]) -> GeneratedCsv:
+        prompt = _PROMPT_TEMPLATES.get(menu_id)
+        if not prompt:
+            raise HTTPException(status_code=404, detail="지원하지 않는 생성 메뉴입니다.")
+
+        if not uploads:
+            raise HTTPException(status_code=422, detail="업로드된 자료가 없습니다. 파일을 추가해 주세요.")
+
+        buffered: List[Tuple[str, bytes]] = []
+        for upload in uploads:
+            try:
+                data = await upload.read()
+                name = upload.filename or "업로드된_파일"
+                buffered.append((name, data))
+            finally:
+                await upload.close()
+
+        preview = self._preview_from_uploads(buffered)
+
+        user_prompt = (
+            f"{prompt['instruction']}\n\n"
+            "다음은 업로드된 자료의 요약입니다. 이를 참고하여 CSV를 생성하세요.\n"
+            f"{preview}\n\n"
+            "CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요."
+        )
+
+        client = self._get_client()
+        try:
+            response = await asyncio.to_thread(
+                client.responses.create,
+                model=self._settings.openai_model,
+                input=[
+                    {
+                        "role": "system",
+                        "content": [{"type": "text", "text": prompt["system"]}],
+                    },
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": user_prompt}],
+                    },
+                ],
+                temperature=0.2,
+                max_output_tokens=1500,
+            )
+        except APIError as exc:
+            raise HTTPException(status_code=502, detail=f"OpenAI 호출 중 오류가 발생했습니다: {exc}") from exc
+        except Exception as exc:  # pragma: no cover - 안전망
+            raise HTTPException(status_code=502, detail="OpenAI 응답을 가져오는 중 예기치 않은 오류가 발생했습니다.") from exc
+
+        csv_text = getattr(response, "output_text", None)
+        if not csv_text:
+            raise HTTPException(status_code=502, detail="OpenAI 응답에서 CSV를 찾을 수 없습니다.")
+
+        sanitized = self._sanitize_csv(csv_text)
+        if not sanitized:
+            raise HTTPException(status_code=502, detail="생성된 CSV 내용이 비어 있습니다.")
+
+        encoded = sanitized.encode("utf-8-sig")
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        safe_project = re.sub(r"[^A-Za-z0-9_-]+", "_", project_id)
+        filename = f"{safe_project}_{menu_id}_{timestamp}.csv"
+
+        return GeneratedCsv(filename=filename, content=encoded)


### PR DESCRIPTION
## Summary
- extend backend configuration and dependency container to expose an AI generation service
- implement an OpenAI-powered CSV generation pipeline that reads uploaded files and builds prompts per menu
- update the project asset generation route to stream the AI-produced CSV back to the frontend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8f2c73464833087f2c0f35234ddf4