### PR TITLE
Add text extraction for AI upload previews

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -1,0 +1,116 @@
+"""Utilities for building OpenAI Responses API payloads.
+
+이 모듈은 다양한 입력 형식을 Responses API 사양에 맞게
+표준화하기 위한 도우미를 제공합니다.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Literal, MutableMapping, Sequence, TypedDict
+
+Role = Literal["system", "user", "assistant", "tool"]
+
+_TextContentType = Literal["input_text", "output_text", "summary_text"]
+
+
+class TextContent(TypedDict):
+    """Response API text 기반 콘텐츠."""
+
+    type: _TextContentType
+    text: str
+
+
+class Message(TypedDict):
+    """Responses API 메시지 구조."""
+
+    role: Role
+    content: List[TextContent]
+
+
+class OpenAIMessageBuilder:
+    """Responses API용 메시지를 생성하고 정규화하는 헬퍼."""
+
+    _ROLE_TEXT_TYPE: MutableMapping[Role, _TextContentType] = {
+        "system": "input_text",
+        "user": "input_text",
+        "assistant": "output_text",
+        "tool": "output_text",
+    }
+
+    @classmethod
+    def text_message(
+        cls,
+        role: Role,
+        text: str,
+        *,
+        content_type: _TextContentType | None = None,
+    ) -> Message:
+        """주어진 역할과 텍스트로 단일 파트 메시지를 생성합니다."""
+
+        normalized_type = content_type or cls._ROLE_TEXT_TYPE.get(role, "input_text")
+        return {
+            "role": role,
+            "content": [
+                {
+                    "type": normalized_type,
+                    "text": text,
+                }
+            ],
+        }
+
+    @classmethod
+    def normalize_messages(cls, messages: Sequence[MutableMapping[str, object]]) -> List[Message]:
+        """Responses API 입력 스펙에 맞도록 메시지 배열을 정규화합니다.
+
+        구 버전 포맷(예: type="text" 또는 문자열 콘텐츠)을 허용하고,
+        현재 스펙에 맞춰 type 값을 변환합니다.
+        """
+
+        normalized: List[Message] = []
+        for raw in messages:
+            role = raw.get("role")
+            if role not in cls._ROLE_TEXT_TYPE:
+                raise ValueError(f"알 수 없는 메시지 역할입니다: {role!r}")
+
+            contents = raw.get("content")
+            if contents is None:
+                raise ValueError("메시지에 content가 없습니다.")
+
+            normalized_contents: List[TextContent] = []
+            if isinstance(contents, str):
+                normalized_contents.append(
+                    {
+                        "type": cls._ROLE_TEXT_TYPE[role],
+                        "text": contents,
+                    }
+                )
+            else:
+                if not isinstance(contents, Iterable):
+                    raise ValueError("content는 문자열 또는 Iterable 이어야 합니다.")
+                for item in contents:  # type: ignore[assignment]
+                    if not isinstance(item, MutableMapping):
+                        raise ValueError("content 항목은 매핑이어야 합니다.")
+                    part_type = item.get("type")
+                    if part_type in {None, "text"}:
+                        normalized_contents.append(
+                            {
+                                "type": cls._ROLE_TEXT_TYPE[role],
+                                "text": str(item.get("text", "")),
+                            }
+                        )
+                    elif part_type in {"input_text", "output_text", "summary_text"}:
+                        normalized_contents.append(
+                            {
+                                "type": part_type,
+                                "text": str(item.get("text", "")),
+                            }
+                        )
+                    else:
+                        raise ValueError(f"지원하지 않는 content type입니다: {part_type!r}")
+
+            if not normalized_contents:
+                raise ValueError("정규화된 content가 비어 있습니다.")
+
+            normalized.append({"role": role, "content": normalized_contents})
+
+        return normalized

--- a/backend/app/services/text_extraction.py
+++ b/backend/app/services/text_extraction.py
@@ -1,0 +1,229 @@
+"""Helpers for extracting readable text previews from uploads."""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+from dataclasses import dataclass
+from html import unescape
+from html.parser import HTMLParser
+from typing import Callable, Optional
+
+
+@dataclass
+class ExtractedUploadPreview:
+    """Structured preview for an uploaded file."""
+
+    header: str
+    body: str
+
+
+class _HTMLTextParser(HTMLParser):
+    _BLOCK_TAGS = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "div",
+        "dl",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "td",
+        "th",
+        "tr",
+        "ul",
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs):  # type: ignore[override]
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n")
+
+    def handle_endtag(self, tag: str):  # type: ignore[override]
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n")
+
+    def handle_data(self, data: str):  # type: ignore[override]
+        if data:
+            self._chunks.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._chunks)
+        text = unescape(text)
+        text = re.sub(r"[\r\t]", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = re.sub(r"\s{2,}", " ", text)
+        return text.strip()
+
+
+def _decode_text(raw: bytes, *, errors: str = "strict") -> str:
+    for encoding in ("utf-8", "cp949"):
+        try:
+            return raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", errors=errors)
+
+
+def _decode_text_lenient(raw: bytes) -> str:
+    return _decode_text(raw, errors="ignore")
+
+
+def _extract_pdf(raw: bytes) -> str:
+    texts: list[str] = []
+
+    try:  # pragma: no cover - optional dependency path
+        from PyPDF2 import PdfReader  # type: ignore
+
+        try:
+            reader = PdfReader(io.BytesIO(raw))
+        except Exception:
+            reader = None
+        if reader is not None:
+            for page in getattr(reader, "pages", []):
+                try:
+                    value = page.extract_text()  # type: ignore[attr-defined]
+                except Exception:  # pragma: no cover - PyPDF2 internal errors
+                    value = None
+                if value:
+                    texts.append(value)
+    except Exception:
+        pass
+
+    if texts:
+        return "\n".join(texts).strip()
+
+    decoded = raw.decode("latin-1", errors="ignore")
+    candidate_segments: list[str] = []
+
+    # Match both (text) Tj and [(text1) (text2)] TJ patterns
+    for match in re.findall(r"\(([^()]*)\)\s*T[jJ]", decoded):
+        candidate_segments.append(match)
+
+    for array in re.findall(r"\[((?:\([^\)]*\)\s*)+)\]\s*TJ", decoded):
+        for match in re.findall(r"\(([^()]*)\)", array):
+            candidate_segments.append(match)
+
+    if not candidate_segments:
+        return ""
+
+    def _unescape(segment: str) -> str:
+        replacements = {
+            r"\\n": "\n",
+            r"\\r": "\n",
+            r"\\t": "\t",
+            r"\\b": "",
+            r"\\f": "",
+            r"\\(": "(",
+            r"\\)": ")",
+            r"\\\\": "\\",
+        }
+        for pattern, replacement in replacements.items():
+            segment = segment.replace(pattern, replacement)
+        return segment
+
+    cleaned = [_unescape(seg) for seg in candidate_segments]
+    return "\n".join(s for s in cleaned if s).strip()
+
+
+def _extract_html(raw: bytes) -> str:
+    parser = _HTMLTextParser()
+    try:
+        parser.feed(_decode_text(raw, errors="ignore"))
+        parser.close()
+    except Exception:
+        return ""
+    return parser.get_text()
+
+def _default_message(filename: str) -> str:
+    return (
+        "텍스트를 추출하지 못했습니다. 파일 내용을 직접 확인해 주세요. "
+        f"(파일명: {filename})"
+    )
+
+
+def _extract_text_by_strategy(raw: bytes, strategy: Callable[[bytes], str]) -> str:
+    try:
+        text = strategy(raw)
+    except Exception:
+        text = ""
+    return text.strip()
+
+
+def _normalize_whitespace(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\u3000", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def extract_text_preview(
+    *,
+    filename: str,
+    raw: bytes,
+    content_type: Optional[str],
+    max_chars: int,
+) -> ExtractedUploadPreview:
+    extension = os.path.splitext(filename)[1].lower()
+
+    strategies: list[Callable[[bytes], str]] = []
+
+    if extension in {".txt", ".csv"} or (content_type or "").startswith("text/"):
+        strategies.extend([_decode_text, _decode_text_lenient])
+    elif extension in {".html", ".htm"} or (content_type == "text/html"):
+        strategies.append(_extract_html)
+    elif extension == ".pdf" or content_type == "application/pdf":
+        strategies.append(_extract_pdf)
+    else:
+        # Attempt generic text decode as a fallback before giving up
+        strategies.append(_decode_text_lenient)
+
+    text = ""
+    for strategy in strategies:
+        text = _extract_text_by_strategy(raw, strategy)
+        if text:
+            break
+
+    if not text:
+        if extension == ".pdf" or (content_type == "application/pdf"):
+            text = _default_message(filename)
+        elif (content_type or "").startswith("image/"):
+            text = (
+                "이미지에서 텍스트를 추출할 수 없습니다. 필요하다면 OCR 결과를 제공해 주세요."
+            )
+        else:
+            text = _default_message(filename)
+
+    normalized = _normalize_whitespace(text)
+    if not normalized:
+        normalized = _default_message(filename)
+
+    if len(normalized) > max_chars:
+        normalized = normalized[:max_chars].rstrip() + "\n... (이후 내용 생략)"
+
+    header = f"### 파일: {filename}"
+    return ExtractedUploadPreview(header=header, body=normalized)

--- a/backend/tests/test_text_extraction.py
+++ b/backend/tests/test_text_extraction.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import base64
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.text_extraction import extract_text_preview
+
+
+class TextExtractionTests(unittest.TestCase):
+    def test_extract_pdf_text(self) -> None:
+        pdf_base64 = (
+            "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5k"
+            "b2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUl0KL0NvdW50IDEKPj4KZW5kb2Jq"
+            "CjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovTWVkaWFCb3ggWzAgMCAyMDAgMjAw"
+            "XQovQ29udGVudHMgNCAwIFIKL1Jlc291cmNlcyA8PAovRm9udCA8PAovRjEgNSAwIFIKPj4KPj4KPj4K"
+            "ZW5kb2JqCjQgMCBvYmoKPDwKL0xlbmd0aCA0NAo+PnN0cmVhbQpCVAovRjEgMjQgVGYKNTAgMTUwIFRk"
+            "CihIZWxsbyBQREYpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKNSAwIG9iago8PAovVHlwZSAvRm9udAov"
+            "U3VidHlwZSAvVHlwZTEKL0Jhc2VGb250IC9IZWx2ZXRpY2EKPj4KZW5kb2JqCnhyZWYKMCA2CjAwMDAw"
+            "MDAwMCA2NTUzNSBmIAowMDAwMDAwMTAgMDAwMDAgbiAKMDAwMDAwMDcxIDAwMDAwIG4gCjAwMDAwMDE2"
+            "NCAwMDAwMCBuIAowMDAwMDAyNTUgMDAwMDAgbiAKMDAwMDAwMzU4IDAwMDAwIG4gCnRyYWlsZXIKPDwK"
+            "L1Jvb3QgMSAwIFIKL1NpemUgNgovSW5mbyA3IDAgUgo+PgpzdGFydHhyZWYKNDc2CiUlRU9G"
+        )
+        pdf_bytes = base64.b64decode(pdf_base64)
+        preview = extract_text_preview(
+            filename="sample.pdf",
+            raw=pdf_bytes,
+            content_type="application/pdf",
+            max_chars=2000,
+        )
+        self.assertIn("Hello PDF", preview.body)
+
+    def test_extract_html_text(self) -> None:
+        html_bytes = "<html><body><h1>제목</h1><p>본문 내용입니다.</p></body></html>".encode("utf-8")
+        preview = extract_text_preview(
+            filename="sample.html",
+            raw=html_bytes,
+            content_type="text/html",
+            max_chars=500,
+        )
+        self.assertIn("제목", preview.body)
+        self.assertIn("본문 내용입니다.", preview.body)
+
+    def test_extract_image_fallback(self) -> None:
+        image_bytes = b"\xff\xd8\xff"  # JPEG header bytes
+        preview = extract_text_preview(
+            filename="image.jpg",
+            raw=image_bytes,
+            content_type="image/jpeg",
+            max_chars=500,
+        )
+        self.assertIn("이미지에서 텍스트를 추출할 수 없습니다", preview.body)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace base64-based file previews with extracted text snippets when building OpenAI prompts
- add a reusable text extraction helper that understands PDF, HTML, and text uploads with graceful fallbacks
- add regression tests covering PDF, HTML, and unsupported image inputs for the new preview logic

## Testing
- python -m compileall backend/app/services
- python -m unittest backend.tests.test_text_extraction


------
https://chatgpt.com/codex/tasks/task_e_68d8f71128288330bfc95920dc38e68c