### PR TITLE
feat: update auth flow and drive navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -66,6 +66,34 @@
   color: white;
 }
 
+.app-shell__logout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.55);
+  background: transparent;
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-shell__logout:hover,
+.app-shell__logout:focus-visible {
+  background: rgba(226, 232, 240, 0.18);
+  color: #ffffff;
+  border-color: rgba(226, 232, 240, 0.85);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+}
+
+.app-shell__logout:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.9);
+  outline-offset: 2px;
+}
+
 .app-shell__main {
   flex: 1;
   display: flex;
@@ -260,6 +288,14 @@
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
+}
+
+.drive-page__actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
 }
 
 .drive-page__auth-message {
@@ -1032,6 +1068,18 @@
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
+}
+
+.project-management-content__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.project-management-content__toolbar .project-management-content__button,
+.project-management-content__toolbar .project-management-content__secondary {
+  align-self: center;
 }
 
 .project-management-content__header {

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,0 +1,82 @@
+export type AuthStatus = 'authenticated' | 'unauthenticated'
+
+const AUTH_STATUS_STORAGE_KEY = 'tta-ai.authStatus'
+
+const subscribers = new Set<(status: AuthStatus) => void>()
+let storageListenerRegistered = false
+
+function readAuthStatus(): AuthStatus {
+  if (typeof window === 'undefined') {
+    return 'unauthenticated'
+  }
+
+  try {
+    const stored = sessionStorage.getItem(AUTH_STATUS_STORAGE_KEY)
+    return stored === 'authenticated' ? 'authenticated' : 'unauthenticated'
+  } catch (error) {
+    console.error('failed to read auth status from storage', error)
+    return 'unauthenticated'
+  }
+}
+
+function notify(status: AuthStatus) {
+  subscribers.forEach((listener) => {
+    try {
+      listener(status)
+    } catch (error) {
+      console.error('auth listener threw an error', error)
+    }
+  })
+}
+
+function ensureStorageListener() {
+  if (storageListenerRegistered || typeof window === 'undefined') {
+    return
+  }
+  storageListenerRegistered = true
+
+  window.addEventListener('storage', (event) => {
+    if (event.key !== AUTH_STATUS_STORAGE_KEY) {
+      return
+    }
+    notify(readAuthStatus())
+  })
+}
+
+export function getAuthStatus(): AuthStatus {
+  return readAuthStatus()
+}
+
+export function markAuthenticated() {
+  if (typeof window !== 'undefined') {
+    try {
+      sessionStorage.setItem(AUTH_STATUS_STORAGE_KEY, 'authenticated')
+    } catch (error) {
+      console.error('failed to persist auth status', error)
+    }
+  }
+  try {
+    notify('authenticated')
+  } catch (error) {
+    console.error('failed to notify auth subscribers', error)
+  }
+}
+
+export function clearAuthentication() {
+  if (typeof window !== 'undefined') {
+    try {
+      sessionStorage.removeItem(AUTH_STATUS_STORAGE_KEY)
+    } catch (error) {
+      console.error('failed to clear auth status', error)
+    }
+  }
+  notify('unauthenticated')
+}
+
+export function subscribeToAuth(listener: (status: AuthStatus) => void): () => void {
+  ensureStorageListener()
+  subscribers.add(listener)
+  return () => {
+    subscribers.delete(listener)
+  }
+}

--- a/frontend/src/components/GoogleLoginCard.tsx
+++ b/frontend/src/components/GoogleLoginCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import { markAuthenticated, clearAuthentication } from '../auth'
 import { DRIVE_AUTH_STORAGE_KEY, getBackendUrl } from '../config'
 import { navigate } from '../navigation'
 
@@ -35,6 +36,8 @@ export function GoogleLoginCard() {
         initialQuery.message ?? 'Google Drive 권한이 성공적으로 연결되었습니다.'
       setMessage(successMessage)
 
+      markAuthenticated()
+
       try {
         const payload = {
           message: successMessage,
@@ -51,6 +54,7 @@ export function GoogleLoginCard() {
     } else if (initialQuery.auth === 'error') {
       setStatus('error')
       setMessage(initialQuery.message ?? 'Google 인증이 취소되었습니다.')
+      clearAuthentication()
     }
 
     if (initialQuery.auth) {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,1 @@
+export const GOOGLE_DRIVE_HOME_URL = 'https://drive.google.com/drive/my-drive' as const

--- a/frontend/src/pages/DriveSetupPage.tsx
+++ b/frontend/src/pages/DriveSetupPage.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../components/layout/PageHeader'
 import { PageLayout } from '../components/layout/PageLayout'
 import { ProjectCreationModal } from '../components/ProjectCreationModal'
 import type { DriveSetupResponse } from '../types/drive'
+import { GOOGLE_DRIVE_HOME_URL } from '../constants'
 
 type ViewState = 'loading' | 'ready' | 'error'
 
@@ -106,6 +107,10 @@ export function DriveSetupPage() {
     setReloadIndex((index) => index + 1)
   }
 
+  const handleOpenDrive = () => {
+    window.open(GOOGLE_DRIVE_HOME_URL, '_blank', 'noopener,noreferrer')
+  }
+
   const projects = result?.projects ?? []
   const folderName = result?.folderName ?? 'gs'
 
@@ -161,6 +166,10 @@ export function DriveSetupPage() {
             ) : (
               <DriveEmptyState onCreateClick={handleOpenModal} />
             )}
+
+            <div className="drive-page__actions">
+              <DriveActionButton onClick={handleOpenDrive}>구글 드라이브 확인</DriveActionButton>
+            </div>
           </DriveCard>
         )}
       </div>

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -6,6 +6,8 @@ import {
   type FileType,
 } from '../components/fileUploaderTypes'
 import { getBackendUrl } from '../config'
+import { GOOGLE_DRIVE_HOME_URL } from '../constants'
+import { navigate } from '../navigation'
 
 type MenuItemId = 'feature-tc' | 'defect-report' | 'security-report' | 'performance-report'
 type MenuGroupId = 'defect-group'
@@ -168,6 +170,14 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const activeContent = MENU_ITEMS.find((item) => item.id === activeItem) ?? MENU_ITEMS[0]
 
   const activeState = itemStates[activeContent.id] ?? createItemState()
+
+  const handleSelectAnotherProject = useCallback(() => {
+    navigate('/drive')
+  }, [])
+
+  const handleOpenDrive = useCallback(() => {
+    window.open(GOOGLE_DRIVE_HOME_URL, '_blank', 'noopener,noreferrer')
+  }, [])
 
   const handleChangeFiles = useCallback(
     (id: MenuItemId, nextFiles: File[]) => {
@@ -488,6 +498,22 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
 
       <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠">
         <div className="project-management-content__inner">
+          <div className="project-management-content__toolbar" role="navigation" aria-label="프로젝트 작업 메뉴">
+            <button
+              type="button"
+              className="project-management-content__secondary project-management-content__toolbar-button"
+              onClick={handleSelectAnotherProject}
+            >
+              다른 프로젝트 선택
+            </button>
+            <button
+              type="button"
+              className="project-management-content__button project-management-content__toolbar-button"
+              onClick={handleOpenDrive}
+            >
+              구글 드라이브 확인
+            </button>
+          </div>
           <div className="project-management-content__header">
             <span className="project-management-content__eyebrow">{activeContent.eyebrow}</span>
             <h1 className="project-management-content__title">{activeContent.title}</h1>


### PR DESCRIPTION
## Summary
- track authentication state in the shell to show a logout action and gate non-login routes
- surface quick links to revisit project selection or open Google Drive from project-related pages
- style the new navigation controls for a consistent header and drive layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d916fa642083309820d0c48611ce4c