### PR TITLE
Redirect authenticated users to Drive setup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,12 @@ function App() {
     }
   }, [authStatus, pathname])
 
+  useEffect(() => {
+    if (authStatus === 'authenticated' && pathname === '/') {
+      navigate('/drive', { replace: true })
+    }
+  }, [authStatus, pathname])
+
   const projectMatch = pathname.match(/^\/projects\/([^/]+)$/)
 
   const pageContent = useMemo(() => {


### PR DESCRIPTION
## Summary
- redirect authenticated users who land on the root path to the Drive setup page so they can immediately manage projects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d91a681ba88330b70bdaaf13a60b5e