### PR TITLE
feat: open Drive workspace from header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { listen, navigate } from './navigation'
 import { DriveSetupPage } from './pages/DriveSetupPage'
 import { LoginPage } from './pages/LoginPage'
 import { ProjectManagementPage } from './pages/ProjectManagementPage'
+import { openGoogleDriveWorkspace } from './drive'
 
 function App() {
   const [pathname, setPathname] = useState<string>(() => window.location.pathname || '/')
@@ -70,7 +71,7 @@ function App() {
   }
 
   const handleOpenDrive = () => {
-    navigate('/drive')
+    openGoogleDriveWorkspace()
   }
 
   const isAuthenticated = authStatus === 'authenticated'

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,3 +1,5 @@
+import { clearDriveRootFolderId } from './drive'
+
 export type AuthStatus = 'authenticated' | 'unauthenticated'
 
 const AUTH_STATUS_STORAGE_KEY = 'tta-ai.authStatus'
@@ -69,6 +71,11 @@ export function clearAuthentication() {
     } catch (error) {
       console.error('failed to clear auth status', error)
     }
+  }
+  try {
+    clearDriveRootFolderId()
+  } catch (error) {
+    console.error('failed to clear drive folder id', error)
   }
   notify('unauthenticated')
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -12,3 +12,4 @@ export function getBackendUrl(): string {
 }
 
 export const DRIVE_AUTH_STORAGE_KEY = 'tta-ai.driveAuthInfo'
+export const DRIVE_ROOT_FOLDER_STORAGE_KEY = 'tta-ai.driveRootFolderId'

--- a/frontend/src/drive.ts
+++ b/frontend/src/drive.ts
@@ -1,0 +1,60 @@
+import { GOOGLE_DRIVE_HOME_URL } from './constants'
+import { DRIVE_ROOT_FOLDER_STORAGE_KEY } from './config'
+
+const GOOGLE_DRIVE_FOLDER_BASE_URL = 'https://drive.google.com/drive/folders'
+const DRIVE_WINDOW_FEATURES = 'noopener,noreferrer'
+
+export function storeDriveRootFolderId(folderId: string | null | undefined) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    if (folderId && folderId.trim().length > 0) {
+      sessionStorage.setItem(DRIVE_ROOT_FOLDER_STORAGE_KEY, folderId)
+    } else {
+      sessionStorage.removeItem(DRIVE_ROOT_FOLDER_STORAGE_KEY)
+    }
+  } catch (error) {
+    console.error('failed to persist drive folder id', error)
+  }
+}
+
+export function readDriveRootFolderId(): string | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const stored = sessionStorage.getItem(DRIVE_ROOT_FOLDER_STORAGE_KEY)
+    if (stored && stored.trim().length > 0) {
+      return stored
+    }
+    return null
+  } catch (error) {
+    console.error('failed to read drive folder id', error)
+    return null
+  }
+}
+
+export function clearDriveRootFolderId() {
+  storeDriveRootFolderId(null)
+}
+
+export function getDriveFolderUrl(folderId: string): string {
+  return `${GOOGLE_DRIVE_FOLDER_BASE_URL}/${encodeURIComponent(folderId)}`
+}
+
+export function openGoogleDriveWorkspace() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.open(GOOGLE_DRIVE_HOME_URL, 'ttaGoogleDriveHome', DRIVE_WINDOW_FEATURES)
+
+  const folderId = readDriveRootFolderId()
+  if (folderId) {
+    const folderUrl = getDriveFolderUrl(folderId)
+    window.open(folderUrl, 'ttaGoogleDriveGs', DRIVE_WINDOW_FEATURES)
+  }
+}

--- a/frontend/src/pages/DriveSetupPage.tsx
+++ b/frontend/src/pages/DriveSetupPage.tsx
@@ -10,7 +10,7 @@ import { PageHeader } from '../components/layout/PageHeader'
 import { PageLayout } from '../components/layout/PageLayout'
 import { ProjectCreationModal } from '../components/ProjectCreationModal'
 import type { DriveSetupResponse } from '../types/drive'
-import { GOOGLE_DRIVE_HOME_URL } from '../constants'
+import { openGoogleDriveWorkspace, storeDriveRootFolderId } from '../drive'
 
 type ViewState = 'loading' | 'ready' | 'error'
 
@@ -66,6 +66,7 @@ export function DriveSetupPage() {
           return
         }
         setResult(data)
+        storeDriveRootFolderId(data.folderId)
         setViewState('ready')
       } catch (error) {
         if (!isMounted || controller.signal.aborted) {
@@ -108,7 +109,7 @@ export function DriveSetupPage() {
   }
 
   const handleOpenDrive = () => {
-    window.open(GOOGLE_DRIVE_HOME_URL, '_blank', 'noopener,noreferrer')
+    openGoogleDriveWorkspace()
   }
 
   const projects = result?.projects ?? []

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -6,7 +6,7 @@ import {
   type FileType,
 } from '../components/fileUploaderTypes'
 import { getBackendUrl } from '../config'
-import { GOOGLE_DRIVE_HOME_URL } from '../constants'
+import { openGoogleDriveWorkspace } from '../drive'
 import { navigate } from '../navigation'
 
 type MenuItemId = 'feature-tc' | 'defect-report' | 'security-report' | 'performance-report'
@@ -176,7 +176,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   }, [])
 
   const handleOpenDrive = useCallback(() => {
-    window.open(GOOGLE_DRIVE_HOME_URL, '_blank', 'noopener,noreferrer')
+    openGoogleDriveWorkspace()
   }, [])
 
   const handleChangeFiles = useCallback(


### PR DESCRIPTION
## Summary
- store the Google Drive root folder id after setup and clear it when logging out
- add shared utilities to open both the Drive home and the gs folder and reuse them across the app
- update the header and project management buttons to launch the Drive workspace instead of navigating internally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91eca8698833086a4ecb671ba3799