### PR TITLE
Redirect authenticated users to project selection page

### DIFF
--- a/frontend/src/app/routing/resolvePage.tsx
+++ b/frontend/src/app/routing/resolvePage.tsx
@@ -6,6 +6,8 @@ import { LoginPage } from '../../pages/LoginPage'
 import { ProjectManagementPage } from '../../pages/ProjectManagementPage'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/([^/]+)$/
+const PROJECTS_ROOT_PATH = '/projects'
+const LEGACY_DRIVE_PATH = '/drive'
 
 interface ResolvePageOptions {
   pathname: string
@@ -17,7 +19,7 @@ export function resolvePage({ pathname, authStatus }: ResolvePageOptions): React
     return <LoginPage />
   }
 
-  if (pathname === '/drive') {
+  if (pathname === PROJECTS_ROOT_PATH || pathname === LEGACY_DRIVE_PATH) {
     return <DriveSetupPage />
   }
 

--- a/frontend/src/app/routing/useRouteGuards.ts
+++ b/frontend/src/app/routing/useRouteGuards.ts
@@ -4,9 +4,11 @@ import type { AuthStatus } from '../../auth'
 import { navigate } from '../../navigation'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/(.+)$/
+const PROJECTS_ROOT_PATH = '/projects'
+const LEGACY_DRIVE_PATH = '/drive'
 
 function isKnownPathname(pathname: string): boolean {
-  if (pathname === '/' || pathname === '/drive') {
+  if (pathname === '/' || pathname === PROJECTS_ROOT_PATH || pathname === LEGACY_DRIVE_PATH) {
     return true
   }
   return PROJECT_PATH_PATTERN.test(pathname)
@@ -26,8 +28,13 @@ export function useRouteGuards(pathname: string, authStatus: AuthStatus) {
   }, [authStatus, pathname])
 
   useEffect(() => {
+    if (pathname === LEGACY_DRIVE_PATH) {
+      navigate(PROJECTS_ROOT_PATH, { replace: true })
+      return
+    }
+
     if (authStatus === 'authenticated' && pathname === '/') {
-      navigate('/drive', { replace: true })
+      navigate(PROJECTS_ROOT_PATH, { replace: true })
     }
   }, [authStatus, pathname])
 }

--- a/frontend/src/components/GoogleLoginCard.tsx
+++ b/frontend/src/components/GoogleLoginCard.tsx
@@ -49,7 +49,7 @@ export function GoogleLoginCard() {
       }
 
       redirectTimer = window.setTimeout(() => {
-        navigate('/drive', { replace: true })
+        navigate('/projects', { replace: true })
       }, 1200)
     } else if (initialQuery.auth === 'error') {
       setStatus('error')

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -171,7 +171,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const activeState = itemStates[activeContent.id] ?? createItemState()
 
   const handleSelectAnotherProject = useCallback(() => {
-    navigate('/drive')
+    navigate('/projects')
   }, [])
 
   const handleChangeFiles = useCallback(


### PR DESCRIPTION
## Summary
- redirect authenticated users to the /projects hub and keep /drive as a legacy alias
- update the login success flow to send people to the project selection page
- adjust project page navigation to return to the project chooser

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d925dc72fc8330835b0c3d42ddf5f4