### PR TITLE
Convert project workspace sidebar to standard menu

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -877,25 +877,23 @@
 }
 
 .project-management-page {
-  width: min(1180px, 100%);
+  width: min(1100px, 100%);
   min-height: 70vh;
-  display: grid;
-  grid-template-columns: minmax(260px, 320px) 1fr;
-  gap: clamp(1.75rem, 3vw, 3rem);
-  padding: clamp(2rem, 4vw, 3rem);
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.98);
-  box-shadow:
-    0 25px 45px rgba(15, 23, 42, 0.1),
-    0 12px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  background: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
 }
 
 .project-management-sidebar {
+  flex: 0 0 260px;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding-right: clamp(0.5rem, 2vw, 1.5rem);
-  border-right: 1px solid rgba(148, 163, 184, 0.3);
+  gap: 1.75rem;
+  padding: 2rem 1.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
 }
 
 .project-management-overview {
@@ -905,210 +903,119 @@
 }
 
 .project-management-overview__label {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #64748b;
+  color: rgba(226, 232, 240, 0.6);
 }
 
 .project-management-overview__name {
-  font-size: 1.45rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  color: #0f172a;
+  line-height: 1.2;
+  color: #ffffff;
   word-break: keep-all;
 }
 
-.project-management-menu__list,
-.project-management-menu__sublist {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.project-management-menu {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
 }
 
-.project-management-menu__sublist {
-  margin-top: 0.75rem;
-  padding: 0.5rem 0.35rem 0.4rem 0.35rem;
-  gap: 0.65rem;
+.project-management-menu__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .project-management-menu__item {
-  font-size: 0.98rem;
-  color: #1f2937;
-}
-
-.project-management-menu__item--secondary {
-  font-size: 0.94rem;
-  color: #334155;
-}
-
-.project-management-menu__item--primary {
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: 18px;
-  background: rgba(248, 250, 252, 0.72);
-  padding: 0.3rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.project-management-menu__item--group {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: none;
-}
-
-.project-management-menu__item--group .project-management-menu__sublist {
-  background: rgba(248, 250, 252, 0.9);
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-}
-
-.project-management-menu__item--expanded.project-management-menu__item--primary,
-.project-management-menu__item--active.project-management-menu__item--primary {
-  border-color: rgba(37, 99, 235, 0.45);
-  background: rgba(59, 130, 246, 0.14);
-  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.14);
+  overflow: hidden;
 }
 
 .project-management-menu__button {
   width: 100%;
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  border: 1px solid transparent;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: none;
+  border-radius: inherit;
   background: transparent;
-  color: inherit;
+  color: rgba(226, 232, 240, 0.75);
   font: inherit;
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.project-management-menu__button--group {
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.project-management-menu__button-leading {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.18);
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.project-management-menu__item--secondary .project-management-menu__button {
-  padding: 0.75rem 0.85rem;
-}
-
-.project-management-menu__item--secondary .project-management-menu__button-leading {
-  width: 1.75rem;
-  height: 1.75rem;
-  background: rgba(148, 163, 184, 0.12);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .project-management-menu__button:hover,
 .project-management-menu__button:focus-visible {
-  border-color: rgba(59, 130, 246, 0.4);
-  background: rgba(59, 130, 246, 0.08);
-  box-shadow: 0 8px 18px rgba(59, 130, 246, 0.12);
+  outline: none;
+  background: rgba(148, 163, 184, 0.18);
+  color: #ffffff;
+  transform: translateX(4px);
 }
 
-.project-management-menu__item--active .project-management-menu__button,
-.project-management-menu__item--expanded .project-management-menu__button {
-  border-color: rgba(37, 99, 235, 0.45);
-  background: rgba(59, 130, 246, 0.12);
-  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.14);
-}
-
-.project-management-menu__indicator {
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: rgba(148, 163, 184, 0.65);
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.project-management-menu__item--active .project-management-menu__button-leading {
-  background: rgba(37, 99, 235, 0.2);
-  transform: scale(1.05);
-}
-
-.project-management-menu__item--active .project-management-menu__indicator {
-  background: #2563eb;
-  transform: scale(1.1);
+.project-management-menu__item--active .project-management-menu__button {
+  background: rgba(59, 130, 246, 0.32);
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.35);
+  transform: none;
 }
 
 .project-management-menu__label {
-  flex: 1;
-  min-width: 0;
   font-weight: 600;
 }
 
-.project-management-menu__item--secondary .project-management-menu__label {
-  font-weight: 500;
-  color: #1f2937;
+.project-management-menu__helper {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
 }
 
-.project-management-menu__chevron {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
-  transition: transform 0.2s ease;
-}
-
-.project-management-menu__chevron--open {
-  transform: rotate(-135deg);
-}
-
-.project-management-menu__sublist--collapsed {
-  display: none;
+.project-management-menu__item--active .project-management-menu__helper {
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .project-management-content {
-  border-radius: 28px;
-  background: linear-gradient(135deg, rgba(248, 250, 252, 0.8), rgba(226, 232, 240, 0.9));
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  flex: 1;
   display: flex;
+  align-items: stretch;
+  background: #f8fafc;
+  padding: 2.5rem;
 }
 
 .project-management-content__inner {
   flex: 1;
-  padding: clamp(2rem, 4vw, 3.5rem);
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2rem;
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+  padding: 2.25rem;
 }
 
 .project-management-content__toolbar {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
   justify-content: flex-end;
-}
-
-.project-management-content__toolbar .project-management-content__button,
-.project-management-content__toolbar .project-management-content__secondary {
-  align-self: center;
+  gap: 0.75rem;
 }
 
 .project-management-content__header {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-width: 620px;
+  max-width: 640px;
 }
 
 .project-management-content__eyebrow {
@@ -1116,7 +1023,7 @@
   align-self: flex-start;
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  background: rgba(59, 130, 246, 0.15);
+  background: rgba(59, 130, 246, 0.14);
   color: #1d4ed8;
   font-size: 0.78rem;
   font-weight: 700;
@@ -1146,7 +1053,7 @@
 
 .project-management-content__section-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   font-weight: 700;
   color: #1e293b;
 }
@@ -1168,41 +1075,40 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  min-width: 220px;
-  padding: 0.9rem 2.4rem;
-  border-radius: 999px;
+  min-width: 210px;
+  padding: 0.85rem 2.25rem;
   border: none;
-  background: linear-gradient(135deg, #2563eb, #4f46e5);
-  color: white;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.28);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .project-management-content__button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.32);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
 }
 
 .project-management-content__button:active {
   transform: translateY(0);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.24);
 }
 
 .project-management-content__button:disabled,
 .project-management-content__button[aria-disabled='true'] {
-  cursor: not-allowed;
   opacity: 0.65;
+  cursor: not-allowed;
   box-shadow: none;
   transform: none;
 }
 
 .project-management-content__footnote {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   color: #64748b;
 }
 
@@ -1222,7 +1128,7 @@
   width: 1rem;
   height: 1rem;
   border-radius: 999px;
-  border: 2px solid rgba(37, 99, 235, 0.3);
+  border: 2px solid rgba(37, 99, 235, 0.25);
   border-top-color: #2563eb;
   animation: project-management-spin 0.75s linear infinite;
 }
@@ -1241,11 +1147,10 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.75rem;
-  padding: 1.35rem 1.5rem;
-  border-radius: 20px;
-  border: 1px solid rgba(59, 130, 246, 0.18);
-  background: rgba(59, 130, 246, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
 }
 
 .project-management-content__download {
@@ -1256,18 +1161,59 @@
   align-self: flex-start;
   padding: 0.6rem 1.5rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background: white;
-  color: #334155;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
   transition: color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .project-management-content__secondary:hover {
-  border-color: rgba(59, 130, 246, 0.6);
-  color: #2563eb;
-  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.14);
+  color: #1e40af;
+  border-color: #94a3b8;
+  box-shadow: 0 10px 20px rgba(148, 163, 184, 0.24);
+}
+
+@media (max-width: 1024px) {
+  .project-management-page {
+    flex-direction: column;
+  }
+
+  .project-management-sidebar {
+    flex: none;
+    width: 100%;
+    padding: 1.75rem 1.5rem;
+    border-right: none;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.2);
+  }
+
+  .project-management-content {
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .project-management-page {
+    border-radius: 20px;
+  }
+
+  .project-management-sidebar {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .project-management-menu__button {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .project-management-content {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .project-management-content__inner {
+    padding: 1.75rem;
+    border-radius: 16px;
+  }
 }
 
 @keyframes project-management-spin {
@@ -1277,29 +1223,6 @@
 
   to {
     transform: rotate(360deg);
-  }
-}
-
-@media (max-width: 1024px) {
-  .project-management-page {
-    grid-template-columns: 1fr;
-    padding: clamp(1.75rem, 4vw, 2.5rem);
-  }
-
-  .project-management-sidebar {
-    border-right: none;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.3);
-    padding-bottom: 1.5rem;
-  }
-}
-
-@media (max-width: 720px) {
-  .project-management-menu__button {
-    padding: 0.75rem 0.9rem;
-  }
-
-  .project-management-content__inner {
-    padding: clamp(1.5rem, 6vw, 2.5rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the hierarchical project workspace navigation with a straightforward sidebar menu using the existing entry metadata
- refresh the sidebar and content panel styling to match the simplified layout and responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d92613919483308da03c0929c32a2f