### PR TITLE
Fix auth subscription to deliver current status immediately

### DIFF
--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -83,6 +83,12 @@ export function clearAuthentication() {
 export function subscribeToAuth(listener: (status: AuthStatus) => void): () => void {
   ensureStorageListener()
   subscribers.add(listener)
+
+  try {
+    listener(readAuthStatus())
+  } catch (error) {
+    console.error('auth listener threw an error during subscription', error)
+  }
   return () => {
     subscribers.delete(listener)
   }


### PR DESCRIPTION
## Summary
- ensure newly registered auth listeners receive the current status so the UI reacts after Drive login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d938a92a3883309474ff06e2da6368