### PR TITLE
Enforce required documents for feature and testcase generation

### DIFF
--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -11,6 +12,20 @@ from ..services.ai_generation import AIGenerationService
 from ..services.google_drive import GoogleDriveService
 
 router = APIRouter()
+
+
+_REQUIRED_MENU_DOCUMENTS: Dict[str, List[Dict[str, str]]] = {
+    "feature-list": [
+        {"id": "user-manual", "label": "사용자 매뉴얼"},
+        {"id": "configuration", "label": "형상 문서"},
+        {"id": "vendor-feature-list", "label": "업체 기능리스트"},
+    ],
+    "testcase-generation": [
+        {"id": "user-manual", "label": "사용자 매뉴얼"},
+        {"id": "configuration", "label": "형상 문서"},
+        {"id": "vendor-feature-list", "label": "업체 기능리스트"},
+    ],
+}
 
 
 @router.post("/drive/gs/setup")
@@ -54,9 +69,66 @@ async def generate_project_asset(
     project_id: str,
     menu_id: str = Form(..., description="생성할 메뉴 ID"),
     files: Optional[List[UploadFile]] = File(None),
+    file_metadata: Optional[str] = Form(
+        None, description="업로드된 파일에 대한 메타데이터(JSON 배열)"
+    ),
     ai_generation_service: AIGenerationService = Depends(get_ai_generation_service),
 ) -> StreamingResponse:
     uploads = files or []
+    metadata_entries: List[Dict[str, Any]] = []
+    if file_metadata:
+        try:
+            parsed = json.loads(file_metadata)
+        except json.JSONDecodeError as exc:  # pragma: no cover - 방어적 처리
+            raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.") from exc
+
+        if not isinstance(parsed, list):
+            raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.")
+
+        for entry in parsed:
+            if not isinstance(entry, dict):
+                raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.")
+            metadata_entries.append(entry)
+
+    if metadata_entries and len(metadata_entries) != len(uploads):
+        raise HTTPException(status_code=422, detail="파일 메타데이터와 업로드된 파일 수가 일치하지 않습니다.")
+
+    required_docs = _REQUIRED_MENU_DOCUMENTS.get(menu_id, [])
+    if required_docs:
+        if not metadata_entries:
+            raise HTTPException(status_code=422, detail="필수 문서 정보가 누락되었습니다.")
+
+        doc_counts = {doc["id"]: 0 for doc in required_docs}
+        for entry in metadata_entries:
+            role = entry.get("role")
+            if role == "required":
+                doc_id = entry.get("id")
+                if doc_id not in doc_counts:
+                    raise HTTPException(status_code=422, detail="알 수 없는 필수 문서 유형입니다.")
+                doc_counts[doc_id] += 1
+            elif role == "additional":
+                description = str(entry.get("description", "")).strip()
+                if not description:
+                    raise HTTPException(status_code=422, detail="추가 업로드한 문서의 종류를 입력해 주세요.")
+            else:
+                raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.")
+
+        missing = [doc["label"] for doc in required_docs if doc_counts.get(doc["id"], 0) == 0]
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=f"다음 필수 문서를 업로드해 주세요: {', '.join(missing)}",
+            )
+    else:
+        for entry in metadata_entries:
+            role = entry.get("role")
+            if role == "additional":
+                description = str(entry.get("description", "")).strip()
+                if not description:
+                    raise HTTPException(status_code=422, detail="추가 업로드한 문서의 종류를 입력해 주세요.")
+            elif role not in {"required", "additional"}:
+                raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.")
+
     result = await ai_generation_service.generate_csv(project_id=project_id, menu_id=menu_id, uploads=uploads)
 
     headers = {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1064,6 +1064,114 @@
   color: #475569;
 }
 
+.project-management-required__list {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.project-management-required__item {
+  padding: 1rem 1.25rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-required__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.project-management-required__label {
+  font-weight: 700;
+  color: #1e293b;
+  font-size: 1rem;
+}
+
+.project-management-required__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.project-management-additional__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.project-management-additional__input {
+  display: none;
+}
+
+.project-management-additional__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project-management-additional__item {
+  padding: 1rem 1.25rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-management-additional__file {
+  font-weight: 600;
+  color: #1e293b;
+  word-break: break-word;
+}
+
+.project-management-additional__description {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.project-management-additional__description input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-management-additional__description input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.project-management-additional__remove {
+  align-self: flex-end;
+  border: none;
+  background: none;
+  color: #b91c1c;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.project-management-additional__remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .project-management-content__actions {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add menu-specific required document handling with single-file uploads and optional metadata entry
- capture additional file descriptions and include metadata when generating project assets
- validate required document metadata on the backend and extend styling for new upload sections

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbec38a1c48330895c32129dbafb9d