### PR TITLE
Adjust required uploads layout and behavior

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1067,7 +1067,7 @@
 .project-management-required__list {
   display: grid;
   gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .project-management-required__item {
@@ -1081,32 +1081,34 @@
   gap: 0.75rem;
 }
 
-.project-management-required__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
 .project-management-required__label {
   font-weight: 700;
   color: #1e293b;
   font-size: 1rem;
 }
 
-.project-management-required__description {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #64748b;
-}
-
-.project-management-additional__controls {
+.project-management-additional--inline {
+  margin-top: 2rem;
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.project-management-additional__input {
-  display: none;
+.project-management-additional__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.project-management-additional--inline .file-uploader {
+  width: 100%;
+}
+
+@media (max-width: 1024px) {
+  .project-management-required__list {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
 }
 
 .project-management-additional__list {


### PR DESCRIPTION
## Summary
- show all required upload cards in a single row and remove redundant helper copy
- rename the configuration requirement to a JPG-only 형상 이미지 and keep data definitions in sync
- move the additional upload area beneath the required files and switch it to a drag-and-drop uploader

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbf22993208330bf3afc03b70d3e50