### PR TITLE
Log AI prompts and include upload descriptions in context

### DIFF
--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -17,13 +17,13 @@ router = APIRouter()
 _REQUIRED_MENU_DOCUMENTS: Dict[str, List[Dict[str, str]]] = {
     "feature-list": [
         {"id": "user-manual", "label": "사용자 매뉴얼"},
-        {"id": "configuration", "label": "형상 문서"},
+        {"id": "configuration", "label": "형상 이미지"},
         {"id": "vendor-feature-list", "label": "업체 기능리스트"},
     ],
     "testcase-generation": [
         {"id": "user-manual", "label": "사용자 매뉴얼"},
-        {"id": "configuration", "label": "형상 문서"},
-        {"id": "vendor-feature-list", "label": "업체 기능리스트"},
+        {"id": "configuration", "label": "형상 이미지"},
+        {"id": "vendor-feature-list", "label": "기능리스트"},
     ],
 }
 
@@ -129,7 +129,12 @@ async def generate_project_asset(
             elif role not in {"required", "additional"}:
                 raise HTTPException(status_code=422, detail="파일 메타데이터 형식이 올바르지 않습니다.")
 
-    result = await ai_generation_service.generate_csv(project_id=project_id, menu_id=menu_id, uploads=uploads)
+    result = await ai_generation_service.generate_csv(
+        project_id=project_id,
+        menu_id=menu_id,
+        uploads=uploads,
+        metadata=metadata_entries,
+    )
 
     headers = {
         "Content-Disposition": f'attachment; filename="{result.filename}"',

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import logging
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
 
 from fastapi import HTTPException, UploadFile
 from openai import APIError, OpenAI
@@ -27,6 +30,24 @@ class BufferedUpload:
 class GeneratedCsv:
     filename: str
     content: bytes
+
+
+@dataclass
+class UploadContext:
+    upload: BufferedUpload
+    metadata: Dict[str, Any] | None
+
+
+@dataclass
+class PromptContextPreview:
+    descriptor: str
+    doc_id: str | None
+
+
+@dataclass
+class PromptPreview:
+    text: str
+    contexts: List[PromptContextPreview]
 
 
 _PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
@@ -68,6 +89,11 @@ _PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
     },
 }
 
+_MAX_IMAGE_PREVIEW_CHARS = 8000
+
+
+logger = logging.getLogger(__name__)
+
 
 class AIGenerationService:
     def __init__(self, settings: Settings):
@@ -84,23 +110,169 @@ class AIGenerationService:
 
     @staticmethod
     def _preview_from_uploads(
-        uploads: Iterable[BufferedUpload],
-    ) -> str:
+        contexts: Iterable[UploadContext],
+    ) -> PromptPreview:
         sections: List[str] = []
-        for upload in uploads:
-            preview: ExtractedUploadPreview = extract_text_preview(
-                filename=upload.name,
-                raw=upload.content,
-                content_type=upload.content_type,
-                max_chars=_MAX_PREVIEW_CHARS,
-            )
-            sections.append(
-                "\n".join(
-                    part for part in (preview.header, preview.body) if part.strip()
-                )
+        descriptors: List[PromptContextPreview] = []
+
+        for context in contexts:
+            descriptor, doc_id = AIGenerationService._descriptor_from_context(context)
+            body = AIGenerationService._build_body_for_context(context)
+
+            cleaned_descriptor = descriptor.strip() or context.upload.name
+            cleaned_body = body.strip()
+
+            if cleaned_body:
+                sections.append(f"### {cleaned_descriptor}\n{cleaned_body}")
+            else:
+                sections.append(f"### {cleaned_descriptor}")
+
+            descriptors.append(
+                PromptContextPreview(descriptor=cleaned_descriptor, doc_id=doc_id)
             )
 
-        return "\n\n".join(sections)
+        joined = "\n\n".join(section for section in sections if section.strip())
+        return PromptPreview(text=joined, contexts=descriptors)
+
+    @staticmethod
+    def _descriptor_from_context(context: UploadContext) -> tuple[str, str | None]:
+        metadata = context.metadata or {}
+        role = str(metadata.get("role") or "").strip()
+        label = str(
+            metadata.get("label") or metadata.get("description") or ""
+        ).strip()
+
+        extension = AIGenerationService._extension(context.upload)
+
+        if role == "additional":
+            base_label = label or "추가 문서"
+            descriptor = f"추가 문서: {base_label}"
+        elif label:
+            descriptor = label
+        else:
+            descriptor = context.upload.name
+
+        if extension:
+            descriptor = f"{descriptor} ({extension})"
+
+        doc_id = (
+            str(metadata.get("id")) if role == "required" and metadata.get("id") else None
+        )
+        return descriptor, doc_id
+
+    @staticmethod
+    def _extension(upload: BufferedUpload) -> str:
+        extension = os.path.splitext(upload.name)[1].lstrip(".")
+        if extension:
+            extension = extension.upper()
+        elif upload.content_type:
+            subtype = upload.content_type.split("/")[-1]
+            extension = subtype.upper()
+        mapping = {"JPEG": "JPG"}
+        return mapping.get(extension, extension)
+
+    @staticmethod
+    def _is_image(upload: BufferedUpload) -> bool:
+        if upload.content_type and upload.content_type.startswith("image/"):
+            return True
+        extension = os.path.splitext(upload.name)[1].lower()
+        return extension in {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"}
+
+    @staticmethod
+    def _build_body_for_context(context: UploadContext) -> str:
+        upload = context.upload
+        metadata = context.metadata or {}
+        doc_id = metadata.get("id") if metadata.get("role") == "required" else None
+        label = str(metadata.get("label") or "").strip()
+        description = str(metadata.get("description") or "").strip()
+
+        if AIGenerationService._is_image(upload):
+            mime = upload.content_type or "image/jpeg"
+            encoded = base64.b64encode(upload.content).decode("ascii")
+            if len(encoded) > _MAX_IMAGE_PREVIEW_CHARS:
+                encoded = (
+                    encoded[:_MAX_IMAGE_PREVIEW_CHARS].rstrip()
+                    + "\n... (이후 이미지 데이터 생략)"
+                )
+
+            if doc_id == "configuration":
+                context_name = label or "형상 이미지"
+                prefix = f"첨부된 이미지는 {context_name}이며 제품의 형상을 보여줍니다."
+            else:
+                prefix = "첨부된 이미지 파일의 원본 데이터를 제공합니다."
+
+            return (
+                f"{prefix}\n"
+                f"Base64: data:{mime};base64,{encoded}"
+            )
+
+        preview: ExtractedUploadPreview = extract_text_preview(
+            filename=upload.name,
+            raw=upload.content,
+            content_type=upload.content_type,
+            max_chars=_MAX_PREVIEW_CHARS,
+        )
+
+        extension = AIGenerationService._extension(upload)
+
+        if doc_id == "user-manual":
+            context_name = label or "사용자 매뉴얼"
+            intro = f"아래는 {context_name}에서 추출한 주요 내용입니다."
+        elif doc_id == "configuration":
+            context_name = label or "형상 이미지"
+            intro = f"{context_name}와 관련된 문서에서 텍스트 정보를 추출한 결과입니다."
+        elif doc_id == "vendor-feature-list":
+            context_name = label or "기능리스트"
+            intro = f"아래는 {context_name} 자료에서 추출한 표 형식의 내용입니다."
+        elif metadata.get("role") == "additional":
+            if description:
+                intro = f"아래는 추가로 업로드된 문서({description})에서 발췌한 내용입니다."
+            else:
+                intro = "추가로 업로드된 문서에서 발췌한 내용입니다."
+        elif extension == "XLSX":
+            intro = "업로드된 스프레드시트 파일을 텍스트로 전개한 내용입니다."
+        else:
+            intro = "업로드된 문서에서 추출한 내용입니다."
+
+        if extension == "XLSX":
+            suffix = "각 행은 '|' 문자로 셀을 구분합니다."
+            body = f"{intro}\n{suffix}\n{preview.body}" if preview.body else intro
+        else:
+            body = f"{intro}\n{preview.body}" if preview.body else intro
+
+        return body.strip()
+
+    @staticmethod
+    def _closing_note(menu_id: str, contexts: List[PromptContextPreview]) -> str | None:
+        if not contexts:
+            return None
+
+        def describe(preferred_ids: List[str]) -> str:
+            ordered: List[str] = []
+            for doc_id in preferred_ids:
+                match = next(
+                    (context.descriptor for context in contexts if context.doc_id == doc_id),
+                    None,
+                )
+                if match:
+                    ordered.append(match)
+            if len(ordered) == len(preferred_ids):
+                return ", ".join(ordered)
+            return ", ".join(context.descriptor for context in contexts)
+
+        if menu_id == "feature-list":
+            description = describe(["user-manual", "configuration", "vendor-feature-list"])
+            return (
+                f"위 자료는 {description}입니다. 이 자료를 활용하여 기능리스트를 작성해 주세요."
+            )
+
+        if menu_id == "testcase-generation":
+            description = describe(["user-manual", "configuration", "vendor-feature-list"])
+            return (
+                f"위 자료는 {description}입니다. 이 자료를 바탕으로 테스트케이스를 작성해 주세요."
+            )
+
+        return None
 
     @staticmethod
     def _sanitize_csv(text: str) -> str:
@@ -110,7 +282,13 @@ class AIGenerationService:
             cleaned = fence_match.group(1).strip()
         return cleaned
 
-    async def generate_csv(self, project_id: str, menu_id: str, uploads: List[UploadFile]) -> GeneratedCsv:
+    async def generate_csv(
+        self,
+        project_id: str,
+        menu_id: str,
+        uploads: List[UploadFile],
+        metadata: List[Dict[str, Any]] | None = None,
+    ) -> GeneratedCsv:
         prompt = _PROMPT_TEMPLATES.get(menu_id)
         if not prompt:
             raise HTTPException(status_code=404, detail="지원하지 않는 생성 메뉴입니다.")
@@ -133,20 +311,41 @@ class AIGenerationService:
             finally:
                 await upload.close()
 
-        preview = self._preview_from_uploads(buffered)
+        contexts: List[UploadContext] = []
+        metadata = metadata or []
+        for index, upload in enumerate(buffered):
+            entry = metadata[index] if index < len(metadata) else None
+            contexts.append(UploadContext(upload=upload, metadata=entry))
 
-        user_prompt = (
-            f"{prompt['instruction']}\n\n"
-            "다음은 업로드된 자료의 요약입니다. 이를 참고하여 CSV를 생성하세요.\n"
-            f"{preview}\n\n"
-            "CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요."
-        )
+        preview_bundle = self._preview_from_uploads(contexts)
+        closing_note = self._closing_note(menu_id, preview_bundle.contexts)
+
+        user_prompt_parts = [
+            prompt["instruction"],
+            "다음은 업로드된 자료의 요약입니다. 자료의 용도와 형식을 참고하세요.",
+            preview_bundle.text,
+        ]
+        if closing_note:
+            user_prompt_parts.append(closing_note)
+        user_prompt_parts.append("CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.")
+
+        user_prompt = "\n\n".join(part for part in user_prompt_parts if part.strip())
 
         client = self._get_client()
         messages = [
             OpenAIMessageBuilder.text_message("system", prompt["system"]),
             OpenAIMessageBuilder.text_message("user", user_prompt),
         ]
+
+        logger.info(
+            "AI generation prompt assembled",
+            extra={
+                "project_id": project_id,
+                "menu_id": menu_id,
+                "system_prompt": prompt["system"],
+                "user_prompt": user_prompt,
+            },
+        )
 
         try:
             response = await asyncio.to_thread(

--- a/backend/app/services/text_extraction.py
+++ b/backend/app/services/text_extraction.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import io
 import os
 import re
+import zipfile
 from dataclasses import dataclass
 from html import unescape
 from html.parser import HTMLParser
 from typing import Callable, Optional
+from xml.etree import ElementTree as ET
 
 
 @dataclass
@@ -159,6 +161,123 @@ def _extract_html(raw: bytes) -> str:
         return ""
     return parser.get_text()
 
+
+def _extract_xlsx(raw: bytes) -> str:
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+            shared_strings: list[str] = []
+            main_ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+            rel_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            pkg_rel_ns = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+            if "xl/sharedStrings.xml" in archive.namelist():
+                try:
+                    shared_root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+                except Exception:
+                    shared_root = None
+                if shared_root is not None:
+                    for si in shared_root.findall(f".//{{{main_ns}}}si"):
+                        text_parts = [
+                            (node.text or "")
+                            for node in si.findall(f".//{{{main_ns}}}t")
+                        ]
+                        if text_parts:
+                            shared_strings.append("".join(text_parts))
+
+            sheet_targets: dict[str, str] = {}
+            if "xl/_rels/workbook.xml.rels" in archive.namelist():
+                try:
+                    rel_root = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+                except Exception:
+                    rel_root = None
+                if rel_root is not None:
+                    for rel in rel_root.findall(
+                        f".//{{{pkg_rel_ns}}}Relationship"
+                    ):
+                        rel_id = rel.get("Id")
+                        target = rel.get("Target")
+                        if rel_id and target:
+                            sheet_targets[rel_id] = target
+
+            sheets: list[tuple[str, str]] = []
+            rel_attr = f"{{{rel_ns}}}id"
+            if "xl/workbook.xml" in archive.namelist():
+                try:
+                    workbook_root = ET.fromstring(archive.read("xl/workbook.xml"))
+                except Exception:
+                    workbook_root = None
+                if workbook_root is not None:
+                    for sheet in workbook_root.findall(f".//{{{main_ns}}}sheet"):
+                        name = sheet.get("name", "Sheet")
+                        rel_id = sheet.get(rel_attr)
+                        sheet_path: Optional[str] = None
+                        if rel_id and rel_id in sheet_targets:
+                            target = sheet_targets[rel_id]
+                            if target.startswith("/"):
+                                sheet_path = target.lstrip("/")
+                            else:
+                                sheet_path = f"xl/{target}" if not target.startswith("xl/") else target
+                        else:
+                            sheet_id = sheet.get("sheetId")
+                            candidate = f"xl/worksheets/sheet{sheet_id}.xml"
+                            if sheet_id and candidate in archive.namelist():
+                                sheet_path = candidate
+
+                        if sheet_path and sheet_path in archive.namelist():
+                            sheets.append((name, sheet_path))
+
+            if not sheets:
+                sheets = [
+                    (member.rsplit("/", 1)[-1], member)
+                    for member in archive.namelist()
+                    if member.startswith("xl/worksheets/") and member.endswith(".xml")
+                ]
+
+            lines: list[str] = []
+            row_tag = f"{{{main_ns}}}row"
+            cell_tag = f"{{{main_ns}}}c"
+            value_tag = f"{{{main_ns}}}v"
+            inline_tag = f"{{{main_ns}}}is"
+            text_tag = f"{{{main_ns}}}t"
+
+            for sheet_name, path in sheets:
+                try:
+                    sheet_root = ET.fromstring(archive.read(path))
+                except Exception:
+                    continue
+
+                lines.append(f"[시트] {sheet_name}")
+                for row in sheet_root.findall(f".//{row_tag}"):
+                    cells: list[str] = []
+                    for cell in row.findall(cell_tag):
+                        cell_type = cell.get("t")
+                        text = ""
+                        if cell_type == "s":
+                            value_node = cell.find(value_tag)
+                            if value_node is not None and value_node.text is not None:
+                                try:
+                                    index = int(value_node.text)
+                                except ValueError:
+                                    index = -1
+                                if 0 <= index < len(shared_strings):
+                                    text = shared_strings[index]
+                        elif cell_type == "inlineStr":
+                            inline = cell.find(f"{inline_tag}/{text_tag}")
+                            if inline is not None and inline.text:
+                                text = inline.text
+                        else:
+                            value_node = cell.find(value_tag)
+                            if value_node is not None and value_node.text:
+                                text = value_node.text
+                        cells.append(text.strip())
+                    if cells:
+                        lines.append(" | ".join(cells).strip())
+                lines.append("")
+
+            return "\n".join(line for line in lines if line).strip()
+    except Exception:
+        return ""
+
 def _default_message(filename: str) -> str:
     return (
         "텍스트를 추출하지 못했습니다. 파일 내용을 직접 확인해 주세요. "
@@ -198,6 +317,11 @@ def extract_text_preview(
         strategies.append(_extract_html)
     elif extension == ".pdf" or content_type == "application/pdf":
         strategies.append(_extract_pdf)
+    elif extension in {".xlsx"} or (
+        content_type
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    ):
+        strategies.append(_extract_xlsx)
     else:
         # Attempt generic text decode as a fallback before giving up
         strategies.append(_decode_text_lenient)
@@ -215,6 +339,11 @@ def extract_text_preview(
             text = (
                 "이미지에서 텍스트를 추출할 수 없습니다. 필요하다면 OCR 결과를 제공해 주세요."
             )
+        elif extension == ".xlsx" or (
+            content_type
+            == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ):
+            text = _default_message(filename)
         else:
             text = _default_message(filename)
 

--- a/backend/tests/test_text_extraction.py
+++ b/backend/tests/test_text_extraction.py
@@ -3,11 +3,84 @@ from __future__ import annotations
 import base64
 import unittest
 from pathlib import Path
+import io
+import zipfile
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.services.text_extraction import extract_text_preview
+
+
+def _build_sample_xlsx() -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">
+  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>
+  <Default Extension=\"xml\" ContentType=\"application/xml\"/>
+  <Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>
+  <Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>
+  <Override PartName=\"/xl/sharedStrings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\"/>
+</Types>""",
+        )
+        archive.writestr(
+            "_rels/.rels",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "xl/_rels/workbook.xml.rels",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">
+  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>
+  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>
+</Relationships>""",
+        )
+        archive.writestr(
+            "xl/workbook.xml",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">
+  <sheets>
+    <sheet name=\"기능목록\" sheetId=\"1\" r:id=\"rId1\"/>
+  </sheets>
+</workbook>""",
+        )
+        archive.writestr(
+            "xl/sharedStrings.xml",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"6\" uniqueCount=\"6\">
+  <si><t>기능 ID</t></si>
+  <si><t>기능명</t></si>
+  <si><t>설명</t></si>
+  <si><t>FT-001</t></si>
+  <si><t>로그인</t></si>
+  <si><t>사용자 인증</t></si>
+</sst>""",
+        )
+        archive.writestr(
+            "xl/worksheets/sheet1.xml",
+            """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">
+  <sheetData>
+    <row r=\"1\">
+      <c r=\"A1\" t=\"s\"><v>0</v></c>
+      <c r=\"B1\" t=\"s\"><v>1</v></c>
+      <c r=\"C1\" t=\"s\"><v>2</v></c>
+    </row>
+    <row r=\"2\">
+      <c r=\"A2\" t=\"s\"><v>3</v></c>
+      <c r=\"B2\" t=\"s\"><v>4</v></c>
+      <c r=\"C2\" t=\"s\"><v>5</v></c>
+    </row>
+  </sheetData>
+</worksheet>""",
+        )
+    return output.getvalue()
 
 
 class TextExtractionTests(unittest.TestCase):
@@ -53,6 +126,17 @@ class TextExtractionTests(unittest.TestCase):
             max_chars=500,
         )
         self.assertIn("이미지에서 텍스트를 추출할 수 없습니다", preview.body)
+
+    def test_extract_xlsx_text(self) -> None:
+        xlsx_bytes = _build_sample_xlsx()
+        preview = extract_text_preview(
+            filename="features.xlsx",
+            raw=xlsx_bytes,
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            max_chars=2000,
+        )
+        self.assertIn("기능 ID | 기능명 | 설명", preview.body)
+        self.assertIn("FT-001 | 로그인 | 사용자 인증", preview.body)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -120,7 +120,7 @@ const MENU_ITEMS: MenuItemContent[] = [
       { id: 'configuration', label: '형상 이미지', allowedTypes: ['jpg'] },
       {
         id: 'vendor-feature-list',
-        label: '업체 기능리스트',
+        label: '기능리스트',
       },
     ],
   },
@@ -134,15 +134,15 @@ const MENU_ITEMS: MenuItemContent[] = [
     helper: '테스트 대상 기능이 담긴 문서를 업로드해 주세요. 여러 파일을 동시에 첨부할 수 있습니다.',
     buttonLabel: '테스트케이스 생성하기',
     allowedTypes: ALL_FILE_TYPES,
-    requiredDocuments: [
-      { id: 'user-manual', label: '사용자 매뉴얼' },
-      { id: 'configuration', label: '형상 이미지', allowedTypes: ['jpg'] },
-      {
-        id: 'vendor-feature-list',
-        label: '업체 기능리스트',
-      },
-    ],
-  },
+      requiredDocuments: [
+        { id: 'user-manual', label: '사용자 매뉴얼' },
+        { id: 'configuration', label: '형상 이미지', allowedTypes: ['jpg'] },
+        {
+          id: 'vendor-feature-list',
+          label: '기능리스트',
+        },
+      ],
+    },
   {
     id: 'defect-report',
     label: '결함 리포트',


### PR DESCRIPTION
## Summary
- surface upload labels and descriptions when building prompt previews so manuals, 형상 이미지, 기능리스트, and extra files are explicitly identified
- log the assembled system and user prompts for each AI generation request so the final prompt text is visible in application logs

## Testing
- python -m pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dbf87c76208330aaa9cff0037f6da6