### PR TITLE
Hide drag-and-drop area after required files are provided

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -768,6 +768,161 @@
   transform: none;
 }
 
+.file-uploader--grid {
+  gap: 0.75rem;
+}
+
+.file-uploader__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+@media (min-width: 768px) {
+  .file-uploader__grid {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+}
+
+.file-uploader__dropzone--grid {
+  aspect-ratio: 1;
+  width: 100%;
+  min-height: 0;
+  padding: 1.5rem;
+  justify-content: center;
+}
+
+.file-uploader__dropzone-grid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-align: center;
+}
+
+.file-uploader__dropzone-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 2px dashed rgba(37, 99, 235, 0.5);
+  color: #2563eb;
+  font-size: 1.5rem;
+  font-weight: 600;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.file-uploader__dropzone-text {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.file-uploader__dropzone-subtext {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.file-uploader__dropzone-counter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.file-uploader__grid-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.95);
+  overflow: hidden;
+  aspect-ratio: 1;
+}
+
+.file-uploader__grid-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.file-uploader__grid-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  color: #475569;
+}
+
+.file-uploader__grid-fallback-icon {
+  font-size: 1.5rem;
+}
+
+.file-uploader__grid-fallback-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.file-uploader__grid-name {
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: 0.6rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.65);
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-uploader__grid-remove {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.6rem;
+  background: rgba(15, 23, 42, 0.65);
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.file-uploader__grid-remove:hover {
+  background: rgba(15, 23, 42, 0.8);
+  transform: translateY(-1px);
+}
+
+.file-uploader__grid-remove:disabled {
+  background: rgba(148, 163, 184, 0.55);
+  cursor: not-allowed;
+  transform: none;
+}
+
+.file-uploader__grid-helper {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #64748b;
+  text-align: center;
+}
+
 .drive-projects__list {
   margin: 0;
   padding: 0;

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ChangeEvent, DragEvent } from 'react'
 
 import {
@@ -12,6 +12,9 @@ interface FileUploaderProps {
   files: File[]
   onChange: (files: File[]) => void
   disabled?: boolean
+  maxFiles?: number
+  variant?: 'list' | 'grid'
+  hideDropzoneWhenFilled?: boolean
 }
 
 function formatBytes(bytes: number): string {
@@ -29,11 +32,35 @@ function createFileKey(file: File) {
   return `${file.name}-${file.size}-${file.lastModified}`
 }
 
-export function FileUploader({ allowedTypes, files, onChange, disabled = false }: FileUploaderProps) {
+function isPreviewableImage(file: File): boolean {
+  if (file.type.startsWith('image/')) {
+    return true
+  }
+
+  const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
+  return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'heic', 'heif'].includes(extension)
+}
+
+export function FileUploader({
+  allowedTypes,
+  files,
+  onChange,
+  disabled = false,
+  maxFiles,
+  variant = 'list',
+  hideDropzoneWhenFilled = false,
+}: FileUploaderProps) {
   const [isDragging, setIsDragging] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const activeTypes = allowedTypes.length > 0 ? allowedTypes : ALL_FILE_TYPES
+
+  const maxFileCount = Number.isFinite(maxFiles) && maxFiles !== undefined ? Math.max(0, Math.floor(maxFiles)) : undefined
+  const shouldHideForFilled = hideDropzoneWhenFilled && files.length > 0
+  const atCapacity = maxFileCount !== undefined && files.length >= maxFileCount
+  const dropzoneDisabled = disabled || atCapacity || shouldHideForFilled
+  const shouldRenderDropzone = !atCapacity && !shouldHideForFilled
+  const isGridVariant = variant === 'grid'
 
   const acceptValue = useMemo(() => {
     return activeTypes.flatMap((type) => FILE_TYPE_OPTIONS[type].accept).join(',')
@@ -43,8 +70,35 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
     return activeTypes.map((type) => FILE_TYPE_OPTIONS[type].label).join(', ')
   }, [activeTypes])
 
+  const previewItems = useMemo(() => {
+    return files.map((file) => ({
+      key: createFileKey(file),
+      url: isPreviewableImage(file) ? URL.createObjectURL(file) : null,
+    }))
+  }, [files])
+
+  const previewMap = useMemo(() => {
+    const map = new Map<string, string>()
+    previewItems.forEach((item) => {
+      if (item.url) {
+        map.set(item.key, item.url)
+      }
+    })
+    return map
+  }, [previewItems])
+
+  useEffect(() => {
+    return () => {
+      previewItems.forEach((item) => {
+        if (item.url) {
+          URL.revokeObjectURL(item.url)
+        }
+      })
+    }
+  }, [previewItems])
+
   const handleDragOver = (event: DragEvent<HTMLLabelElement>) => {
-    if (disabled) {
+    if (dropzoneDisabled) {
       return
     }
 
@@ -55,7 +109,7 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
   }
 
   const handleDragLeave = (event: DragEvent<HTMLLabelElement>) => {
-    if (disabled) {
+    if (dropzoneDisabled) {
       return
     }
 
@@ -70,6 +124,11 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
       return
     }
 
+    if (atCapacity) {
+      setError('업로드 가능한 파일 수를 모두 채웠습니다.')
+      return
+    }
+
     if (incoming.length === 0) {
       return
     }
@@ -77,8 +136,13 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
     const allowed: File[] = []
     const rejected: string[] = []
     const existingKeys = new Set(files.map(createFileKey))
+    let remaining = maxFileCount !== undefined ? maxFileCount - files.length : Number.POSITIVE_INFINITY
 
     incoming.forEach((file) => {
+      if (remaining <= 0) {
+        return
+      }
+
       const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
       const matchesType = activeTypes.some((type) => {
         const info = FILE_TYPE_OPTIONS[type]
@@ -97,6 +161,7 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
 
       existingKeys.add(key)
       allowed.push(file)
+      remaining -= 1
     })
 
     if (rejected.length > 0) {
@@ -111,7 +176,7 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
   }
 
   const handleDrop = (event: DragEvent<HTMLLabelElement>) => {
-    if (disabled) {
+    if (dropzoneDisabled) {
       return
     }
 
@@ -122,7 +187,7 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
   }
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (disabled) {
+    if (dropzoneDisabled) {
       event.target.value = ''
       return
     }
@@ -139,54 +204,121 @@ export function FileUploader({ allowedTypes, files, onChange, disabled = false }
 
     const nextFiles = files.filter((_, currentIndex) => currentIndex !== index)
     onChange(nextFiles)
+    setError(null)
   }
 
-  return (
-    <div className="file-uploader">
-      <label
-        className={`file-uploader__dropzone${
-          isDragging ? ' file-uploader__dropzone--active' : ''
-        }${disabled ? ' file-uploader__dropzone--disabled' : ''}`}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        <input
-          type="file"
-          className="file-uploader__input"
-          accept={acceptValue}
-          multiple
-          onChange={handleInputChange}
-          disabled={disabled}
-        />
-        <div className="file-uploader__prompt">
-          <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
+  const dropzone = shouldRenderDropzone ? (
+    <label
+      className={`file-uploader__dropzone${
+        isDragging ? ' file-uploader__dropzone--active' : ''
+      }${dropzoneDisabled ? ' file-uploader__dropzone--disabled' : ''}${
+        isGridVariant ? ' file-uploader__dropzone--grid' : ''
+      }`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <input
+        type="file"
+        className="file-uploader__input"
+        accept={acceptValue}
+        multiple
+        onChange={handleInputChange}
+        disabled={dropzoneDisabled}
+      />
+      {isGridVariant ? (
+        <div className="file-uploader__dropzone-grid">
+          <span aria-hidden="true" className="file-uploader__dropzone-icon">
+            +
+          </span>
+          <span className="file-uploader__dropzone-text">이미지를 추가하세요</span>
+          <span className="file-uploader__dropzone-subtext">허용된 형식: {allowedLabels}</span>
+          {maxFileCount !== undefined && (
+            <span className="file-uploader__dropzone-counter">
+              {files.length}/{maxFileCount}
+            </span>
+          )}
         </div>
-        <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
-      </label>
+      ) : (
+        <>
+          <div className="file-uploader__prompt">
+            <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
+          </div>
+          <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
+        </>
+      )}
+    </label>
+  ) : null
 
-      {error && <p className="file-uploader__error" role="alert">{error}</p>}
-
-      {files.length > 0 && (
-        <ul className="file-uploader__files">
-          {files.map((file, index) => (
-            <li key={createFileKey(file)} className="file-uploader__file">
-              <div>
-                <span className="file-uploader__file-name">{file.name}</span>
-                <span className="file-uploader__file-size">{formatBytes(file.size)}</span>
+  return (
+    <div className={`file-uploader${isGridVariant ? ' file-uploader--grid' : ''}`}>
+      {isGridVariant ? (
+        <div className="file-uploader__grid">
+          {files.map((file, index) => {
+            const key = createFileKey(file)
+            const previewUrl = previewMap.get(key)
+            return (
+              <div key={key} className="file-uploader__grid-item">
+                {previewUrl ? (
+                  <img src={previewUrl} alt="업로드된 이미지 미리보기" className="file-uploader__grid-preview" />
+                ) : (
+                  <div className="file-uploader__grid-fallback">
+                    <span className="file-uploader__grid-fallback-icon" aria-hidden="true">
+                      📄
+                    </span>
+                    <span className="file-uploader__grid-fallback-label">{formatBytes(file.size)}</span>
+                  </div>
+                )}
+                <span className="file-uploader__grid-name" title={file.name}>
+                  {file.name}
+                </span>
+                <button
+                  type="button"
+                  className="file-uploader__grid-remove"
+                  onClick={() => handleRemove(index)}
+                  aria-label={`${file.name} 삭제`}
+                  disabled={disabled}
+                >
+                  삭제
+                </button>
               </div>
-              <button
-                type="button"
-                className="file-uploader__remove"
-                onClick={() => handleRemove(index)}
-                aria-label={`${file.name} 삭제`}
-                disabled={disabled}
-              >
-                삭제
-              </button>
-            </li>
-          ))}
-        </ul>
+            )
+          })}
+          {dropzone}
+        </div>
+      ) : (
+        <>
+          {dropzone}
+          {error && <p className="file-uploader__error" role="alert">{error}</p>}
+          {files.length > 0 && (
+            <ul className="file-uploader__files">
+              {files.map((file, index) => (
+                <li key={createFileKey(file)} className="file-uploader__file">
+                  <div>
+                    <span className="file-uploader__file-name">{file.name}</span>
+                    <span className="file-uploader__file-size">{formatBytes(file.size)}</span>
+                  </div>
+                  <button
+                    type="button"
+                    className="file-uploader__remove"
+                    onClick={() => handleRemove(index)}
+                    aria-label={`${file.name} 삭제`}
+                    disabled={disabled}
+                  >
+                    삭제
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+      {isGridVariant && error && <p className="file-uploader__error" role="alert">{error}</p>}
+      {isGridVariant && !shouldRenderDropzone && maxFileCount !== undefined && (
+        <p className="file-uploader__grid-helper">최대 {maxFileCount}개의 이미지를 업로드할 수 있습니다.</p>
+      )}
+      {isGridVariant && shouldRenderDropzone && (
+        <p className="file-uploader__grid-helper">허용된 형식: {allowedLabels}</p>
       )}
     </div>
   )

--- a/frontend/src/components/ProjectCreationModal.tsx
+++ b/frontend/src/components/ProjectCreationModal.tsx
@@ -106,7 +106,12 @@ export function ProjectCreationModal({
             업로드한 파일은 생성되는 프로젝트의 ‘0. 사전 자료’ 폴더에 저장됩니다.
           </p>
 
-          <FileUploader allowedTypes={PDF_ONLY} files={files} onChange={setFiles} />
+          <FileUploader
+            allowedTypes={PDF_ONLY}
+            files={files}
+            onChange={setFiles}
+            hideDropzoneWhenFilled
+          />
 
           {formError && (
             <p className="modal__error" role="alert">

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -23,6 +23,8 @@ interface MenuItemContent {
   helper: string
   buttonLabel: string
   allowedTypes: FileType[]
+  uploaderVariant?: 'list' | 'grid'
+  maxFiles?: number
 }
 
 type GenerationStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -427,6 +429,8 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                 files={activeState.files}
                 onChange={(nextFiles) => handleChangeFiles(activeContent.id, nextFiles)}
                 disabled={activeState.status === 'loading'}
+                variant={activeContent.uploaderVariant}
+                maxFiles={activeContent.maxFiles}
               />
             </section>
           )}


### PR DESCRIPTION
## Summary
- add an option for the shared FileUploader to hide its drag-and-drop target once the required files are present
- collapse the project creation modal’s uploader after a PDF is attached
- tighten the grid uploader column sizes so image slots shrink to keep the overall footprint steady

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68dd334e4c448330afb8e94448b34d71