### PR TITLE
Attach uploads as input files when generating CSV

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
+# Ensure the backend/app package is importable when running tests from the repository root.
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.config import Settings
+from app.services.ai_generation import AIGenerationService
+
+
+class _StubFiles:
+    def __init__(self) -> None:
+        self.created: list[dict[str, object]] = []
+        self.deleted: list[str] = []
+
+    def create(self, *, file: tuple[str, io.BytesIO], purpose: str) -> SimpleNamespace:
+        name, handle = file
+        # Read the content to verify what would be sent to OpenAI.
+        content = handle.read()
+        self.created.append({"name": name, "content": content, "purpose": purpose})
+        return SimpleNamespace(id=f"file-{len(self.created)}")
+
+    def delete(self, *, file_id: str) -> None:
+        self.deleted.append(file_id)
+
+
+class _StubResponses:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(output_text="col1,col2\nvalue1,value2")
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.files = _StubFiles()
+        self.responses = _StubResponses()
+
+
+def _settings() -> Settings:
+    return Settings(
+        client_id="",
+        client_secret="",
+        redirect_uri="",
+        frontend_redirect_url="http://localhost",
+        tokens_path=Path("/tmp/tokens.db"),
+        openai_api_key="test-key",
+        openai_model="gpt-test",
+    )
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_generate_csv_attaches_files_and_cleans_up() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    uploads = [
+        (
+            "사용자_매뉴얼.docx",
+            io.BytesIO(b"Document body 1"),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+        (
+            "설계_이미지.png",
+            io.BytesIO(b"Image bytes"),
+            "image/png",
+        ),
+    ]
+
+    fastapi_uploads: list[UploadFile] = []
+    for name, file, content_type in uploads:
+        headers = Headers({"content-type": content_type})
+        upload = UploadFile(file=file, filename=name, headers=headers)
+        fastapi_uploads.append(upload)
+
+    metadata = [
+        {"role": "required", "id": "user-manual", "label": "사용자 설명서"},
+        {"role": "additional", "description": "설계 참고 이미지"},
+    ]
+
+    result = await service.generate_csv(
+        project_id="proj-123",
+        menu_id="feature-list",
+        uploads=fastapi_uploads,
+        metadata=metadata,
+    )
+
+    # Ensure each upload was transmitted as a file to OpenAI with the assistants purpose.
+    assert [entry["purpose"] for entry in stub_client.files.created] == ["assistants", "assistants"]
+
+    # The response payload should include input_file parts for each uploaded file.
+    assert len(stub_client.responses.calls) == 1
+    messages = stub_client.responses.calls[0]["input"]
+    assert isinstance(messages, list)
+    user_message = messages[1]
+    file_parts = [part for part in user_message["content"] if part["type"] == "input_file"]
+    assert [part["file_id"] for part in file_parts] == ["file-1", "file-2"]
+
+    # The text portions should not include the raw upload bodies.
+    text_parts = [part["text"] for part in user_message["content"] if part["type"] == "input_text"]
+    combined_text = "\n".join(text_parts)
+    assert "Document body 1" not in combined_text
+    assert "Image bytes" not in combined_text
+
+    # Temporary files should be cleaned up after the request completes.
+    assert stub_client.files.deleted == ["file-1", "file-2"]
+
+    assert result.csv_text == "col1,col2\nvalue1,value2"
+

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the backend/app package is importable when running tests from the repository root.
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.services.openai_payload import OpenAIMessageBuilder
+
+
+def test_text_message_appends_file_parts() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "hello",
+        file_ids=["file-a", "file-b"],
+    )
+
+    assert message["role"] == "user"
+    assert message["content"][0] == {"type": "input_text", "text": "hello"}
+    assert message["content"][1:] == [
+        {"type": "input_file", "file_id": "file-a"},
+        {"type": "input_file", "file_id": "file-b"},
+    ]
+
+
+def test_normalize_messages_allows_input_file_parts() -> None:
+    raw_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "summary"},
+                {"type": "input_file", "file_id": "file-42"},
+            ],
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "summary"},
+                {"type": "input_file", "file_id": "file-42"},
+            ],
+        }
+    ]
+
+
+def test_text_message_rejects_blank_file_id() -> None:
+    with pytest.raises(ValueError):
+        OpenAIMessageBuilder.text_message("user", "hello", file_ids=[" "])


### PR DESCRIPTION
## Summary
- extend `OpenAIMessageBuilder` to append `input_file` parts and normalize file attachments
- update the CSV generation service to upload user files to OpenAI, attach file references in prompts, and clean them up after use
- add regression tests that cover mixed text/file messages and verify file uploads plus prompt contents

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68df679a4b8c833098406e4ffe90df41