### PR TITLE
Support image uploads in AI CSV generation

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -111,8 +111,15 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     messages = stub_client.responses.calls[0]["input"]
     assert isinstance(messages, list)
     user_message = messages[1]
-    file_parts = [part for part in user_message["content"] if part["type"] == "input_file"]
-    assert [part["file_id"] for part in file_parts] == ["file-1", "file-2"]
+    file_parts = [
+        part
+        for part in user_message["content"]
+        if part["type"] in {"input_file", "input_image"}
+    ]
+    assert file_parts == [
+        {"type": "input_file", "file_id": "file-1"},
+        {"type": "input_image", "image_id": "file-2"},
+    ]
 
     # The text portions should not include the raw upload bodies.
     text_parts = [part["text"] for part in user_message["content"] if part["type"] == "input_text"]

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -28,6 +28,27 @@ def test_text_message_appends_file_parts() -> None:
     ]
 
 
+def test_text_message_appends_image_parts() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "see this",
+        attachments=[{"file_id": "img-1", "kind": "image"}],
+    )
+
+    assert message["role"] == "user"
+    assert message["content"][1:] == [{"type": "input_image", "image_id": "img-1"}]
+
+
+def test_attachments_to_chat_completions_converts_images() -> None:
+    attachments = [{"file_id": "img-2", "kind": "image"}]
+
+    completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
+
+    assert completion_parts == [
+        {"type": "image_url", "image_url": {"url": "openai://file/img-2"}}
+    ]
+
+
 def test_normalize_messages_allows_input_file_parts() -> None:
     raw_messages = [
         {


### PR DESCRIPTION
## Summary
- add image attachment support to the OpenAI payload builder and expose a helper for chat completions
- classify uploads as documents or images when generating CSVs so image files are attached as `input_image`
- cover PNG uploads in the payload and AI generation tests to verify serialization and file uploads

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68df734a7fec83308ec1b821b7a7f0f8