### PR TITLE
Fix Responses API image payload structure

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -118,7 +118,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image_id": "file-2"},
+        {"type": "input_image", "image": {"file_id": "file-2"}},
     ]
 
     # The text portions should not include the raw upload bodies.

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -36,7 +36,9 @@ def test_text_message_appends_image_parts() -> None:
     )
 
     assert message["role"] == "user"
-    assert message["content"][1:] == [{"type": "input_image", "image_id": "img-1"}]
+    assert message["content"][1:] == [
+        {"type": "input_image", "image": {"file_id": "img-1"}}
+    ]
 
 
 def test_attachments_to_chat_completions_converts_images() -> None:
@@ -68,6 +70,30 @@ def test_normalize_messages_allows_input_file_parts() -> None:
             "content": [
                 {"type": "input_text", "text": "summary"},
                 {"type": "input_file", "file_id": "file-42"},
+            ],
+        }
+    ]
+
+
+def test_normalize_messages_converts_legacy_image_id() -> None:
+    raw_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "check"},
+                {"type": "input_image", "image_id": "img-legacy"},
+            ],
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "check"},
+                {"type": "input_image", "image": {"file_id": "img-legacy"}},
             ],
         }
     ]


### PR DESCRIPTION
## Summary
- align the `InputImageContent` structure with the Responses API image payload
- normalize `input_image` content by converting legacy `image_id` entries to the canonical shape
- adjust unit tests to cover the updated payload format

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68df75bf13dc8330a538b38c0de21792