### PR TITLE
Fix OpenAI image payload and improve image uploader previews

### DIFF
--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -37,7 +37,7 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image": {"file_id": "img-1"}}
+        {"type": "input_image", "image_url": {"url": "openai://file/img-1"}}
     ]
 
 
@@ -93,7 +93,10 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image": {"file_id": "img-legacy"}},
+                {
+                    "type": "input_image",
+                    "image_url": {"url": "openai://file/img-legacy"},
+                },
             ],
         }
     ]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -669,6 +669,13 @@
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
+.file-uploader__dropzone--preview {
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 1.5rem;
+  min-height: 220px;
+}
+
 .file-uploader__dropzone:hover {
   border-color: #2563eb;
   box-shadow: 0 10px 20px rgba(37, 99, 235, 0.12);
@@ -723,6 +730,69 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: 0.75rem;
+}
+
+.file-uploader__preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 0.65rem;
+}
+
+.file-uploader__preview-item {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.file-uploader__preview-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.file-uploader__preview-fallback {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.file-uploader__preview-remove {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.file-uploader__preview-remove:hover,
+.file-uploader__preview-remove:focus-visible {
+  background: rgba(15, 23, 42, 0.85);
+  transform: translateY(-1px);
+}
+
+.file-uploader__preview-remove:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.file-uploader__preview-helper {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #475569;
+  text-align: center;
 }
 
 .file-uploader__file {


### PR DESCRIPTION
## Summary
- update OpenAI message builder to use image_url references and normalize legacy image payloads
- refresh image uploader to keep the dropzone visible for required image sets and show a responsive preview grid
- extend styling to support multi-image previews with inline removal controls

## Testing
- pytest backend/tests/test_openai_payload.py
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df77d031e48330a88076fd974bf443