### PR TITLE
Fix OpenAI image payload format

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -126,7 +126,7 @@ class OpenAIMessageBuilder:
                 parts.append(
                     {
                         "type": "input_image",
-                        "image": {"file_id": file_id},
+                        "image_url": {"url": f"openai://file/{file_id}"},
                     }
                 )
             else:  # pragma: no cover - typing guard
@@ -264,7 +264,7 @@ class OpenAIMessageBuilder:
 
         return {
             "type": "input_image",
-            "image": {"file_id": file_id},
+            "image_url": {"url": f"openai://file/{file_id}"},
         }
 
     @staticmethod

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -118,7 +118,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image": {"file_id": "file-2"}},
+        {"type": "input_image", "image_url": {"url": "openai://file/file-2"}},
     ]
 
     # The text portions should not include the raw upload bodies.

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -95,7 +95,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
                 {"type": "input_text", "text": "check"},
                 {
                     "type": "input_image",
-                    "image": {"file_id": "img-legacy"},
+                    "image_url": {"url": "openai://file/img-legacy"},
                 },
             ],
         }
@@ -126,7 +126,10 @@ def test_normalize_messages_accepts_image_mapping() -> None:
         {
             "role": "user",
             "content": [
-                {"type": "input_image", "image": {"file_id": "img-direct"}},
+                {
+                    "type": "input_image",
+                    "image_url": {"url": "openai://file/img-direct"},
+                },
             ],
         }
     ]
@@ -151,7 +154,10 @@ def test_normalize_messages_converts_image_url_string() -> None:
         {
             "role": "user",
             "content": [
-                {"type": "input_image", "image": {"file_id": "img-from-url"}},
+                {
+                    "type": "input_image",
+                    "image_url": {"url": "openai://file/img-from-url"},
+                },
             ],
         }
     ]


### PR DESCRIPTION
## Summary
- update the OpenAI payload builder to send image attachments using `image_url` references
- normalize legacy image inputs into the new Responses API image format
- adjust tests to reflect the updated image payload structure

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e06d94d08c8330a7bc63927728e347