### PR TITLE
Fix Responses API image_url string format

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -28,13 +28,7 @@ class InputImageContent(TypedDict):
     """Response API image reference content."""
 
     type: _ImageContentType
-    image: "ImageReference"
-
-
-class ImageReference(TypedDict):
-    """Reference to an uploaded image asset."""
-
-    file_id: str
+    image_url: str
 
 
 class TextContent(TypedDict):
@@ -126,7 +120,7 @@ class OpenAIMessageBuilder:
                 parts.append(
                     {
                         "type": "input_image",
-                        "image": {"file_id": file_id},
+                        "image_url": f"openai://file/{file_id}",
                     }
                 )
             else:  # pragma: no cover - typing guard
@@ -264,7 +258,7 @@ class OpenAIMessageBuilder:
 
         return {
             "type": "input_image",
-            "image": {"file_id": file_id},
+            "image_url": f"openai://file/{file_id}",
         }
 
     @staticmethod
@@ -281,7 +275,7 @@ class OpenAIMessageBuilder:
                 completion_parts.append(
                     {
                         "type": "image_url",
-                        "image_url": {"url": f"openai://file/{file_id}"},
+                        "image_url": f"openai://file/{file_id}",
                     }
                 )
         return completion_parts

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -118,7 +118,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image": {"file_id": "file-2"}},
+        {"type": "input_image", "image_url": "openai://file/file-2"},
     ]
 
     # The text portions should not include the raw upload bodies.

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -37,7 +37,7 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": {"url": "openai://file/img-1"}}
+        {"type": "input_image", "image_url": "openai://file/img-1"}
     ]
 
 
@@ -47,7 +47,7 @@ def test_attachments_to_chat_completions_converts_images() -> None:
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "image_url", "image_url": {"url": "openai://file/img-2"}}
+        {"type": "image_url", "image_url": "openai://file/img-2"}
     ]
 
 
@@ -95,7 +95,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
                 {"type": "input_text", "text": "check"},
                 {
                     "type": "input_image",
-                    "image": {"file_id": "img-legacy"},
+                    "image_url": "openai://file/img-legacy",
                 },
             ],
         }
@@ -126,7 +126,10 @@ def test_normalize_messages_accepts_image_mapping() -> None:
         {
             "role": "user",
             "content": [
-                {"type": "input_image", "image": {"file_id": "img-direct"}},
+                {
+                    "type": "input_image",
+                    "image_url": "openai://file/img-direct",
+                },
             ],
         }
     ]
@@ -151,7 +154,10 @@ def test_normalize_messages_converts_image_url_string() -> None:
         {
             "role": "user",
             "content": [
-                {"type": "input_image", "image": {"file_id": "img-from-url"}},
+                {
+                    "type": "input_image",
+                    "image_url": "openai://file/img-from-url",
+                },
             ],
         }
     ]


### PR DESCRIPTION
## Summary
- send Responses API input_image parts with string image_url references instead of nested objects
- normalize legacy image payloads to the string format and update typing/tests accordingly

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e06d94d08c8330a7bc63927728e347