### PR TITLE
Normalize AI generation payload image references

### DIFF
--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -335,6 +335,8 @@ class AIGenerationService:
                 ),
             ]
 
+            normalized_messages = OpenAIMessageBuilder.normalize_messages(messages)
+
             logger.info(
                 "AI generation prompt assembled",
                 extra={
@@ -349,7 +351,7 @@ class AIGenerationService:
                 response = await asyncio.to_thread(
                     client.responses.create,
                     model=self._settings.openai_model,
-                    input=messages,
+                    input=normalized_messages,
                     temperature=0.2,
                     max_output_tokens=1500,
                 )

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -37,6 +37,11 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
+        {"type": "input_image", "image_url": "openai://file/img-1"}
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages([message])
+    assert normalized[0]["content"][1:] == [
         {"type": "input_image", "image": {"file_id": "img-1"}}
     ]
 


### PR DESCRIPTION
## Summary
- normalize AI generation request messages before invoking the OpenAI Responses API
- extend AI generation service tests to cover normalization of image_url content
- adjust payload builder tests to verify conversion of attachment image URLs during normalization

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e07491a8488330b59b911f1f5ff18c