### PR TITLE
Normalize image attachments to use image_url

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -25,24 +25,11 @@ class InputFileContent(TypedDict):
     file_id: str
 
 
-class ImageObject(TypedDict):
-    """Image reference that points to an uploaded OpenAI file."""
-
-    file_id: str
-
-
 class InputImageURLContent(TypedDict):
     """Response API image content that references an external URL."""
 
     type: _ImageContentType
     image_url: str
-
-
-class InputImageFileContent(TypedDict):
-    """Response API image content that references an uploaded file."""
-
-    type: _ImageContentType
-    image: ImageObject
 
 
 class TextContent(TypedDict):
@@ -52,7 +39,7 @@ class TextContent(TypedDict):
     text: str
 
 
-ContentPart = TextContent | InputFileContent | InputImageURLContent | InputImageFileContent
+ContentPart = TextContent | InputFileContent | InputImageURLContent
 
 
 class AttachmentMetadata(TypedDict):
@@ -227,7 +214,7 @@ class OpenAIMessageBuilder:
     @classmethod
     def _normalize_image_part(
         cls, item: MutableMapping[str, object]
-    ) -> InputImageURLContent | InputImageFileContent:
+    ) -> InputImageURLContent:
         image: object | None = item.get("image")
         image_url: object | None = item.get("image_url")
         image_id: object | None = item.get("image_id")
@@ -277,7 +264,7 @@ class OpenAIMessageBuilder:
         if isinstance(file_id, str) and file_id.strip():
             return {
                 "type": "input_image",
-                "image": {"file_id": file_id},
+                "image_url": f"openai://file/{file_id}",
             }
 
         if isinstance(external_url, str) and external_url.strip():

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -119,7 +119,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image": {"file_id": "file-2"}},
+        {"type": "input_image", "image_url": "openai://file/file-2"},
     ]
 
     # The text portions should not include the raw upload bodies.
@@ -179,6 +179,6 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image": {"file_id": "file-extra"},
+        "image_url": "openai://file/file-extra",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -42,7 +42,7 @@ def test_text_message_appends_image_parts() -> None:
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image": {"file_id": "img-1"}}
+        {"type": "input_image", "image_url": "openai://file/img-1"}
     ]
 
 
@@ -98,7 +98,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image": {"file_id": "img-legacy"}},
+                {"type": "input_image", "image_url": "openai://file/img-legacy"},
             ],
         }
     ]
@@ -130,7 +130,7 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image": {"file_id": "img-direct"},
+                    "image_url": "openai://file/img-direct",
                 },
             ],
         }
@@ -158,7 +158,7 @@ def test_normalize_messages_converts_image_url_string() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image": {"file_id": "img-from-url"},
+                    "image_url": "openai://file/img-from-url",
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- normalize uploaded image references to emit `openai://file/...` URLs in the Responses payloads
- adjust OpenAI payload and AI generation tests to assert the new schema

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e077709eac8330a00b6efde036765b