### PR TITLE
Update OpenAI image URL scheme

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -121,7 +121,7 @@ class OpenAIMessageBuilder:
                 parts.append(
                     {
                         "type": "input_image",
-                        "image_url": f"openai://file-{file_id}",
+                        "image_url": f"openai://{file_id}",
                     }
                 )
             else:  # pragma: no cover - typing guard
@@ -205,10 +205,16 @@ class OpenAIMessageBuilder:
     def _file_id_from_openai_url(url: object | None) -> str | None:
         if not isinstance(url, str):
             return None
-        prefix = "openai://file-"
-        if not url.startswith(prefix):
+        if not url.startswith("openai://"):
             return None
-        file_id = url[len(prefix) :].strip()
+        remainder = url[len("openai://") :].strip()
+        if not remainder:
+            return None
+
+        if remainder.startswith("file-file-"):
+            remainder = remainder[len("file-") :]
+
+        file_id = remainder
         return file_id or None
 
     @classmethod
@@ -241,7 +247,7 @@ class OpenAIMessageBuilder:
                         external_url = image_url
                     else:
                         raise ValueError(
-                            "input_image 항목의 image_url는 유효한 URL이거나 openai://file- 형식이어야 합니다."
+                            "input_image 항목의 image_url는 유효한 URL이거나 openai://{file_id} 형식이어야 합니다."
                         )
             elif isinstance(image_url, MutableMapping):
                 url_value = image_url.get("url")
@@ -251,7 +257,7 @@ class OpenAIMessageBuilder:
                         external_url = url_value
                     else:
                         raise ValueError(
-                            "input_image 항목의 image_url.url은 유효한 URL이거나 openai://file- 형식이어야 합니다."
+                            "input_image 항목의 image_url.url은 유효한 URL이거나 openai://{file_id} 형식이어야 합니다."
                         )
             elif image_url is not None:
                 raise ValueError(
@@ -264,7 +270,7 @@ class OpenAIMessageBuilder:
         if isinstance(file_id, str) and file_id.strip():
             return {
                 "type": "input_image",
-                "image_url": f"openai://file-{file_id}",
+                "image_url": f"openai://{file_id}",
             }
 
         if isinstance(external_url, str) and external_url.strip():
@@ -298,7 +304,7 @@ class OpenAIMessageBuilder:
                 completion_parts.append(
                     {
                         "type": "image_url",
-                        "image_url": f"openai://file-{file_id}",
+                        "image_url": f"openai://{file_id}",
                     }
                 )
         return completion_parts

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -119,7 +119,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image_url": "openai://file-file-2"},
+        {"type": "input_image", "image_url": "openai://file-2"},
     ]
 
     # The text portions should not include the raw upload bodies.
@@ -179,6 +179,6 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image_url": "openai://file-file-extra",
+        "image_url": "openai://file-extra",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -37,12 +37,12 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-img-1"}
+        {"type": "input_image", "image_url": "openai://img-1"}
     ]
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-img-1"}
+        {"type": "input_image", "image_url": "openai://img-1"}
     ]
 
 
@@ -52,7 +52,7 @@ def test_attachments_to_chat_completions_converts_images() -> None:
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "image_url", "image_url": "openai://file-img-2"}
+        {"type": "image_url", "image_url": "openai://img-2"}
     ]
 
 
@@ -98,7 +98,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image_url": "openai://file-img-legacy"},
+                {"type": "input_image", "image_url": "openai://img-legacy"},
             ],
         }
     ]
@@ -130,7 +130,7 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://file-img-direct",
+                    "image_url": "openai://img-direct",
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- update OpenAI payload helpers to emit image URLs using the openai://{file_id} scheme and accept legacy inputs
- refresh unit tests to expect the normalized URLs produced by the new scheme

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e07bfc5ffc8330a1a3007324469cde