### PR TITLE
Restore Responses API file URL prefix

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -119,7 +119,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image_url": "openai://file-2"},
+        {"type": "input_image", "image_url": "openai://file-file-2"},
     ]
 
     # The text portions should not include the raw upload bodies.
@@ -179,6 +179,6 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image_url": "openai://file-extra",
+        "image_url": "openai://file-file-extra",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -32,27 +32,27 @@ def test_text_message_appends_image_parts() -> None:
     message = OpenAIMessageBuilder.text_message(
         "user",
         "see this",
-        attachments=[{"file_id": "img-1", "kind": "image"}],
+        attachments=[{"file_id": "file-img-1", "kind": "image"}],
     )
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://img-1"}
+        {"type": "input_image", "image_url": "openai://file-file-img-1"}
     ]
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://img-1"}
+        {"type": "input_image", "image_url": "openai://file-file-img-1"}
     ]
 
 
 def test_attachments_to_chat_completions_converts_images() -> None:
-    attachments = [{"file_id": "img-2", "kind": "image"}]
+    attachments = [{"file_id": "file-img-2", "kind": "image"}]
 
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "image_url", "image_url": "openai://img-2"}
+        {"type": "image_url", "image_url": "openai://file-file-img-2"}
     ]
 
 
@@ -86,7 +86,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "text", "text": "check"},
-                {"type": "input_image", "image_id": "img-legacy"},
+                {"type": "input_image", "image_id": "file-img-legacy"},
             ],
         }
     ]
@@ -98,7 +98,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image_url": "openai://img-legacy"},
+                {"type": "input_image", "image_url": "openai://file-file-img-legacy"},
             ],
         }
     ]
@@ -116,7 +116,7 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image": {"file_id": "img-direct"},
+                    "image": {"file_id": "file-img-direct"},
                 }
             ],
         }
@@ -130,7 +130,7 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://img-direct",
+                    "image_url": "openai://file-file-img-direct",
                 },
             ],
         }
@@ -144,7 +144,7 @@ def test_normalize_messages_converts_image_url_string() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://file-img-from-url",
+                    "image_url": "openai://file-file-img-from-url",
                 }
             ],
         }
@@ -158,7 +158,7 @@ def test_normalize_messages_converts_image_url_string() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://file-img-from-url",
+                    "image_url": "openai://file-file-img-from-url",
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- ensure image attachments emit `openai://file-{file_id}` URLs across message builders and chat completion helpers
- tighten internal OpenAI file URL parsing and refresh validation messaging for the restored format
- update payload and AI generation tests to expect the reinstated `openai://file-file-…` references

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e087a6d0408330a07a58a652bb9a9c