### PR TITLE
Support image URL attachments

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -151,6 +151,12 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
                     "image_url": {"url": "openai://file-file-extra"},
                 }
             )
+            message["content"].append(  # type: ignore[index]
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,abc123",
+                }
+            )
         return message
 
     monkeypatch.setattr(OpenAIMessageBuilder, "text_message", _augmented_text_message)
@@ -180,5 +186,9 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     assert {
         "type": "input_image",
         "image_url": "openai://file-file-extra",
+    } in image_parts
+    assert {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,abc123",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -28,7 +28,7 @@ def test_text_message_appends_file_parts() -> None:
     ]
 
 
-def test_text_message_appends_image_parts() -> None:
+def test_text_message_appends_image_parts_from_file_id() -> None:
     message = OpenAIMessageBuilder.text_message(
         "user",
         "see this",
@@ -46,6 +46,49 @@ def test_text_message_appends_image_parts() -> None:
     ]
 
 
+def test_text_message_appends_image_parts_from_image_url() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "look at this",
+        attachments=[
+            {
+                "image_url": "https://example.com/external.png",
+                "kind": "image",
+            }
+        ],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages([message])
+    assert normalized[0]["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+
+def test_text_message_accepts_image_url_alias() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "alias",
+        attachments=[{"url": "https://example.com/from-alias", "kind": "image"}],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/from-alias",
+        }
+    ]
+
+
 def test_attachments_to_chat_completions_converts_images() -> None:
     attachments = [{"file_id": "file-img-2", "kind": "image"}]
 
@@ -53,6 +96,22 @@ def test_attachments_to_chat_completions_converts_images() -> None:
 
     assert completion_parts == [
         {"type": "image_url", "image_url": "openai://file-file-img-2"}
+    ]
+
+
+def test_attachments_to_chat_completions_prefers_image_url() -> None:
+    attachments = [
+        {
+            "file_id": "file-img-3",
+            "image_url": "data:image/png;base64,abc123",
+            "kind": "image",
+        }
+    ]
+
+    completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
+
+    assert completion_parts == [
+        {"type": "image_url", "image_url": "data:image/png;base64,abc123"}
     ]
 
 
@@ -187,6 +246,35 @@ def test_normalize_messages_preserves_external_image_url() -> None:
                 {
                     "type": "input_image",
                     "image_url": "https://example.com/image.png",
+                },
+            ],
+        }
+    ]
+
+
+def test_normalize_messages_preserves_data_image_url() -> None:
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+    raw_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
+                }
+            ],
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- allow attachment metadata to provide image URLs alongside file IDs
- enhance image normalization and chat completion conversion to preserve external/data URLs
- expand payload and AI generation tests to cover uploads, external URLs, and data URLs

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e08c6d3cac8330a71f74be2e17b53a