### PR TITLE
Fix image attachments to use file references

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Literal, MutableMapping, Sequence, TypedDict
+from typing import Iterable, List, Literal, MutableMapping, Sequence, TypedDict, cast
+from typing import NotRequired, Required
 from urllib.parse import urlparse
 
 Role = Literal["system", "user", "assistant", "tool"]
@@ -25,6 +26,19 @@ class InputFileContent(TypedDict):
     file_id: str
 
 
+class ImageFileReference(TypedDict):
+    """Response API image reference backed by an uploaded file."""
+
+    file_id: str
+
+
+class InputImageFileContent(TypedDict):
+    """Response API image content that references an uploaded file."""
+
+    type: _ImageContentType
+    image: ImageFileReference
+
+
 class InputImageURLContent(TypedDict):
     """Response API image content that references an external URL."""
 
@@ -39,14 +53,17 @@ class TextContent(TypedDict):
     text: str
 
 
-ContentPart = TextContent | InputFileContent | InputImageURLContent
+ContentPart = (
+    TextContent | InputFileContent | InputImageURLContent | InputImageFileContent
+)
 
 
-class AttachmentMetadata(TypedDict):
+class AttachmentMetadata(TypedDict, total=False):
     """Metadata describing how an uploaded asset should be attached."""
 
-    file_id: str
-    kind: _AttachmentKind
+    kind: Required[_AttachmentKind]
+    file_id: NotRequired[str]
+    image_url: NotRequired[str]
 
 
 class Message(TypedDict):
@@ -91,14 +108,46 @@ class OpenAIMessageBuilder:
             for attachment in attachments:
                 if not isinstance(attachment, MutableMapping):
                     raise ValueError("attachment 항목은 매핑이어야 합니다.")
-                file_id = attachment.get("file_id")
                 kind = attachment.get("kind")
-                if not isinstance(file_id, str) or not file_id.strip():
-                    raise ValueError("attachment file_id는 공백이 아닌 문자열이어야 합니다.")
                 if kind not in {"file", "image"}:
                     raise ValueError(f"지원하지 않는 attachment kind입니다: {kind!r}")
+
+                normalized_attachment: MutableMapping[str, object] = {"kind": kind}
+
+                raw_file_id = attachment.get("file_id")
+                if raw_file_id is not None:
+                    if not isinstance(raw_file_id, str) or not raw_file_id.strip():
+                        raise ValueError(
+                            "attachment file_id는 공백이 아닌 문자열이어야 합니다."
+                        )
+                    normalized_attachment["file_id"] = raw_file_id.strip()
+
+                if kind == "file" and "file_id" not in normalized_attachment:
+                    raise ValueError(
+                        "file 첨부에는 file_id가 필요합니다."
+                    )
+
+                if kind == "image":
+                    raw_image_url = attachment.get("image_url")
+                    if raw_image_url is None and "url" in attachment:
+                        raw_image_url = attachment.get("url")
+                    if raw_image_url is not None:
+                        if not isinstance(raw_image_url, str) or not raw_image_url.strip():
+                            raise ValueError(
+                                "image 첨부의 image_url은 공백이 아닌 문자열이어야 합니다."
+                            )
+                        normalized_attachment["image_url"] = raw_image_url.strip()
+
+                    if (
+                        "image_url" not in normalized_attachment
+                        and "file_id" not in normalized_attachment
+                    ):
+                        raise ValueError(
+                            "image 첨부에는 image_url 또는 file_id 중 하나가 필요합니다."
+                        )
+
                 normalized_attachments.append(
-                    {"file_id": file_id, "kind": kind}  # type: ignore[typeddict-item]
+                    cast(AttachmentMetadata, normalized_attachment)
                 )
 
         if file_ids:
@@ -110,19 +159,35 @@ class OpenAIMessageBuilder:
                 )
 
         for attachment in normalized_attachments:
-            file_id = attachment["file_id"]
-            if not isinstance(file_id, str) or not file_id.strip():
-                raise ValueError("attachment file_id는 공백이 아닌 문자열이어야 합니다.")
-
             kind = attachment["kind"]
             if kind == "file":
+                file_id = attachment.get("file_id")
+                if not isinstance(file_id, str) or not file_id.strip():
+                    raise ValueError("file 첨부에는 유효한 file_id가 필요합니다.")
                 parts.append({"type": "input_file", "file_id": file_id})
             elif kind == "image":
-                parts.append(
-                    {
-                        "type": "input_image",
-                        "image_url": f"openai://file-{file_id}",
-                    }
+                image_url = attachment.get("image_url")
+                if isinstance(image_url, str) and image_url.strip():
+                    parts.append(
+                        {
+                            "type": "input_image",
+                            "image_url": image_url,
+                        }
+                    )
+                    continue
+
+                file_id = attachment.get("file_id")
+                if isinstance(file_id, str) and file_id.strip():
+                    parts.append(
+                        {
+                            "type": "input_image",
+                            "image": {"file_id": file_id},
+                        }
+                    )
+                    continue
+
+                raise ValueError(
+                    "image 첨부에는 image_url 또는 file_id 중 하나가 필요합니다."
                 )
             else:  # pragma: no cover - typing guard
                 raise ValueError(f"지원하지 않는 attachment kind입니다: {kind!r}")
@@ -226,7 +291,7 @@ class OpenAIMessageBuilder:
     @classmethod
     def _normalize_image_part(
         cls, item: MutableMapping[str, object]
-    ) -> InputImageURLContent:
+    ) -> InputImageURLContent | InputImageFileContent:
         image: object | None = item.get("image")
         image_url: object | None = item.get("image_url")
         image_id: object | None = item.get("image_id")
@@ -245,47 +310,64 @@ class OpenAIMessageBuilder:
         elif image is not None:
             raise ValueError("input_image 항목의 image 필드는 매핑이어야 합니다.")
 
-        if file_id is None:
-            if isinstance(image_url, str):
-                file_id = cls._file_id_from_openai_url(image_url)
-                if file_id is None:
-                    if cls._is_valid_external_url(image_url):
-                        external_url = image_url
-                    else:
-                        raise ValueError(
-                            "input_image 항목의 image_url는 유효한 URL이거나 openai://file-{file_id} 형식이어야 합니다."
-                        )
-            elif isinstance(image_url, MutableMapping):
-                url_value = image_url.get("url")
-                file_id = cls._file_id_from_openai_url(url_value)
-                if file_id is None:
-                    if isinstance(url_value, str) and cls._is_valid_external_url(url_value):
-                        external_url = url_value
-                    else:
-                        raise ValueError(
-                            "input_image 항목의 image_url.url은 유효한 URL이거나 openai://file-{file_id} 형식이어야 합니다."
-                        )
-            elif image_url is not None:
-                raise ValueError(
-                    "input_image 항목의 image_url 필드는 문자열 또는 매핑이어야 합니다."
-                )
+        if image_url is not None:
+            normalized_url, url_file_id = cls._normalize_image_url_value(image_url)
+            if normalized_url:
+                external_url = normalized_url
+            if url_file_id:
+                file_id = url_file_id
 
-        if file_id is None and isinstance(image_id, str) and image_id.strip():
+        if isinstance(image_id, str) and image_id.strip():
             file_id = image_id.strip()
 
-        if isinstance(file_id, str) and file_id.strip():
-            return {
-                "type": "input_image",
-                "image_url": f"openai://file-{file_id}",
-            }
+        if file_id:
+            return {"type": "input_image", "image": {"file_id": file_id}}
 
-        if isinstance(external_url, str) and external_url.strip():
-            return {
-                "type": "input_image",
-                "image_url": external_url,
-            }
+        if external_url:
+            return {"type": "input_image", "image_url": external_url}
 
         raise ValueError("input_image 항목에는 유효한 이미지 참조가 필요합니다.")
+
+    @classmethod
+    def _normalize_image_url_value(
+        cls, value: object
+    ) -> tuple[str | None, str | None]:
+        raw: object
+        if isinstance(value, MutableMapping):
+            raw = value.get("url")
+        else:
+            raw = value
+
+        if not isinstance(raw, str):
+            raise ValueError(
+                "input_image 항목의 image_url 필드는 문자열 또는 매핑이어야 합니다."
+            )
+
+        candidate = raw.strip()
+        if not candidate:
+            raise ValueError(
+                "input_image 항목의 image_url는 공백이 아닌 문자열이어야 합니다."
+            )
+
+        parsed = urlparse(candidate)
+        if parsed.scheme == "openai":
+            file_id = cls._file_id_from_openai_url(candidate)
+            if file_id is None:
+                raise ValueError(
+                    "input_image 항목의 image_url는 openai://file-{file_id} 형식을 따라야 합니다."
+                )
+            return (None, file_id)
+
+        if parsed.scheme in {"http", "https", "data"}:
+            if cls._is_valid_external_url(candidate):
+                return (candidate, None)
+            raise ValueError(
+                "input_image 항목의 image_url는 유효한 외부 URL이어야 합니다."
+            )
+
+        raise ValueError(
+            "input_image 항목의 image_url는 지원되는 스킴을 사용해야 합니다."
+        )
 
     @staticmethod
     def _is_valid_external_url(value: str) -> bool:
@@ -304,13 +386,37 @@ class OpenAIMessageBuilder:
 
         completion_parts: List[MutableMapping[str, object]] = []
         for attachment in attachments:
-            kind = attachment["kind"]
-            file_id = attachment["file_id"]
-            if kind == "image":
+            kind = attachment.get("kind")
+            if kind != "image":
+                continue
+
+            image_url = attachment.get("image_url")
+            if isinstance(image_url, MutableMapping):
+                raw_url = image_url.get("url")
+                if isinstance(raw_url, str) and raw_url.strip():
+                    completion_parts.append(
+                        {
+                            "type": "input_image",
+                            "image_url": {"url": raw_url.strip()},
+                        }
+                    )
+                    continue
+
+            if isinstance(image_url, str) and image_url.strip():
                 completion_parts.append(
                     {
-                        "type": "image_url",
-                        "image_url": f"openai://file-{file_id}",
+                        "type": "input_image",
+                        "image_url": {"url": image_url},
+                    }
+                )
+                continue
+
+            file_id = attachment.get("file_id")
+            if isinstance(file_id, str) and file_id.strip():
+                completion_parts.append(
+                    {
+                        "type": "input_image",
+                        "image": {"file_id": file_id},
                     }
                 )
         return completion_parts

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -119,7 +119,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image_url": "openai://file-file-2"},
+        {"type": "input_image", "image": {"file_id": "file-2"}},
     ]
 
     # The text portions should not include the raw upload bodies.
@@ -151,6 +151,12 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
                     "image_url": {"url": "openai://file-file-extra"},
                 }
             )
+            message["content"].append(  # type: ignore[index]
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,abc123",
+                }
+            )
         return message
 
     monkeypatch.setattr(OpenAIMessageBuilder, "text_message", _augmented_text_message)
@@ -179,6 +185,10 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image_url": "openai://file-file-extra",
+        "image": {"file_id": "file-extra"},
+    } in image_parts
+    assert {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,abc123",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -28,7 +28,7 @@ def test_text_message_appends_file_parts() -> None:
     ]
 
 
-def test_text_message_appends_image_parts() -> None:
+def test_text_message_appends_image_parts_from_file_id() -> None:
     message = OpenAIMessageBuilder.text_message(
         "user",
         "see this",
@@ -37,12 +37,55 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-file-img-1"}
+        {"type": "input_image", "image": {"file_id": "file-img-1"}}
     ]
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-file-img-1"}
+        {"type": "input_image", "image": {"file_id": "file-img-1"}}
+    ]
+
+
+def test_text_message_appends_image_parts_from_image_url() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "look at this",
+        attachments=[
+            {
+                "image_url": "https://example.com/external.png",
+                "kind": "image",
+            }
+        ],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages([message])
+    assert normalized[0]["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+
+def test_text_message_accepts_image_url_alias() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "alias",
+        attachments=[{"url": "https://example.com/from-alias", "kind": "image"}],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/from-alias",
+        }
     ]
 
 
@@ -52,7 +95,23 @@ def test_attachments_to_chat_completions_converts_images() -> None:
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "image_url", "image_url": "openai://file-file-img-2"}
+        {"type": "input_image", "image": {"file_id": "file-img-2"}}
+    ]
+
+
+def test_attachments_to_chat_completions_prefers_image_url() -> None:
+    attachments = [
+        {
+            "file_id": "file-img-3",
+            "image_url": "data:image/png;base64,abc123",
+            "kind": "image",
+        }
+    ]
+
+    completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
+
+    assert completion_parts == [
+        {"type": "input_image", "image_url": {"url": "data:image/png;base64,abc123"}}
     ]
 
 
@@ -98,7 +157,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image_url": "openai://file-file-img-legacy"},
+                {"type": "input_image", "image": {"file_id": "file-img-legacy"}},
             ],
         }
     ]
@@ -130,7 +189,7 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://file-file-img-direct",
+                    "image": {"file_id": "file-img-direct"},
                 },
             ],
         }
@@ -156,10 +215,7 @@ def test_normalize_messages_converts_image_url_string() -> None:
         {
             "role": "user",
             "content": [
-                {
-                    "type": "input_image",
-                    "image_url": "openai://file-file-img-from-url",
-                },
+                {"type": "input_image", "image": {"file_id": "file-img-from-url"}},
             ],
         }
     ]
@@ -187,6 +243,35 @@ def test_normalize_messages_preserves_external_image_url() -> None:
                 {
                     "type": "input_image",
                     "image_url": "https://example.com/image.png",
+                },
+            ],
+        }
+    ]
+
+
+def test_normalize_messages_preserves_data_image_url() -> None:
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+    raw_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
+                }
+            ],
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- update the OpenAI payload builder to send `input_image` file references instead of synthetic `openai://` URLs and normalize inbound parts accordingly
- adjust chat-completions attachment conversion to emit file-backed images or wrap external URLs in the expected structure
- refresh payload and AI-generation tests covering file uploads, external URLs, and data URLs

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e08c6d3cac8330a71f74be2e17b53a