### PR TITLE
Remove openai URI handling for image attachments

### DIFF
--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -119,7 +119,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
     ]
     assert file_parts == [
         {"type": "input_file", "file_id": "file-1"},
-        {"type": "input_image", "image_url": "openai://file-file-2"},
+        {"type": "input_image", "image": {"file_id": "file-2"}},
     ]
 
     # The text portions should not include the raw upload bodies.
@@ -148,7 +148,13 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
             message["content"].append(  # type: ignore[index]
                 {
                     "type": "input_image",
-                    "image_url": {"url": "openai://file-file-extra"},
+                    "image": {"file_id": "file-extra"},
+                }
+            )
+            message["content"].append(  # type: ignore[index]
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,abc123",
                 }
             )
         return message
@@ -179,6 +185,10 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image_url": "openai://file-file-extra",
+        "image": {"file_id": "file-extra"},
+    } in image_parts
+    assert {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,abc123",
     } in image_parts
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -28,7 +28,7 @@ def test_text_message_appends_file_parts() -> None:
     ]
 
 
-def test_text_message_appends_image_parts() -> None:
+def test_text_message_appends_image_parts_from_file_id() -> None:
     message = OpenAIMessageBuilder.text_message(
         "user",
         "see this",
@@ -37,12 +37,55 @@ def test_text_message_appends_image_parts() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-file-img-1"}
+        {"type": "input_image", "image": {"file_id": "file-img-1"}}
     ]
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image_url": "openai://file-file-img-1"}
+        {"type": "input_image", "image": {"file_id": "file-img-1"}}
+    ]
+
+
+def test_text_message_appends_image_parts_from_image_url() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "look at this",
+        attachments=[
+            {
+                "image_url": "https://example.com/external.png",
+                "kind": "image",
+            }
+        ],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages([message])
+    assert normalized[0]["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/external.png",
+        }
+    ]
+
+
+def test_text_message_accepts_image_url_alias() -> None:
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "alias",
+        attachments=[{"url": "https://example.com/from-alias", "kind": "image"}],
+    )
+
+    assert message["content"][1:] == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/from-alias",
+        }
     ]
 
 
@@ -52,7 +95,23 @@ def test_attachments_to_chat_completions_converts_images() -> None:
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "image_url", "image_url": "openai://file-file-img-2"}
+        {"type": "input_image", "image": {"file_id": "file-img-2"}}
+    ]
+
+
+def test_attachments_to_chat_completions_prefers_image_url() -> None:
+    attachments = [
+        {
+            "file_id": "file-img-3",
+            "image_url": "data:image/png;base64,abc123",
+            "kind": "image",
+        }
+    ]
+
+    completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
+
+    assert completion_parts == [
+        {"type": "input_image", "image_url": {"url": "data:image/png;base64,abc123"}}
     ]
 
 
@@ -98,7 +157,7 @@ def test_normalize_messages_converts_legacy_image_id() -> None:
             "role": "user",
             "content": [
                 {"type": "input_text", "text": "check"},
-                {"type": "input_image", "image_url": "openai://file-file-img-legacy"},
+                {"type": "input_image", "image": {"file_id": "file-img-legacy"}},
             ],
         }
     ]
@@ -130,14 +189,14 @@ def test_normalize_messages_accepts_image_mapping() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": "openai://file-file-img-direct",
+                    "image": {"file_id": "file-img-direct"},
                 },
             ],
         }
     ]
 
 
-def test_normalize_messages_converts_image_url_string() -> None:
+def test_normalize_messages_rejects_openai_scheme() -> None:
     raw_messages = [
         {
             "role": "user",
@@ -150,19 +209,8 @@ def test_normalize_messages_converts_image_url_string() -> None:
         }
     ]
 
-    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
-
-    assert normalized == [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "input_image",
-                    "image_url": "openai://file-file-img-from-url",
-                },
-            ],
-        }
-    ]
+    with pytest.raises(ValueError):
+        OpenAIMessageBuilder.normalize_messages(raw_messages)
 
 
 def test_normalize_messages_preserves_external_image_url() -> None:
@@ -187,6 +235,35 @@ def test_normalize_messages_preserves_external_image_url() -> None:
                 {
                     "type": "input_image",
                     "image_url": "https://example.com/image.png",
+                },
+            ],
+        }
+    ]
+
+
+def test_normalize_messages_preserves_data_image_url() -> None:
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+    raw_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
+                }
+            ],
+        }
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages(raw_messages)
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": data_url,
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- update the OpenAI payload builder to send `input_image` file references instead of synthetic `openai://` URLs and normalize inbound parts accordingly
- remove legacy `openai://` URI handling so normalization and attachments require real file IDs or supported external/data URLs
- refresh payload and AI-generation tests covering file uploads alongside external and data image URLs

## Testing
- pytest backend/tests/test_openai_payload.py backend/tests/test_ai_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68e08c6d3cac8330a71f74be2e17b53a