### PR TITLE
Normalize project route guard path handling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,3 +67,11 @@ export default defineConfig([
   },
 ])
 ```
+
+## Regression verification
+
+To confirm that project routes with query parameters remain accessible:
+
+1. Sign in to the application.
+2. Navigate directly to a project detail page such as `/projects/123?name=demo` using the address bar or an internal link.
+3. Verify that you remain on the project management view (rather than being redirected back to `/projects`) and that reloading the page preserves the view.

--- a/frontend/src/app/routing/useRouteGuards.ts
+++ b/frontend/src/app/routing/useRouteGuards.ts
@@ -8,6 +8,19 @@ const PROJECTS_ROOT_PATH = '/projects'
 const LEGACY_DRIVE_PATH = '/drive'
 const PROMPT_ADMIN_PATH = '/admin/prompts/feature-list'
 
+function normalizePathname(pathname: string): string {
+  if (!pathname) {
+    return '/'
+  }
+
+  const [normalized] = pathname.split(/[?#]/)
+  if (!normalized) {
+    return '/'
+  }
+
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}
+
 function isKnownPathname(pathname: string): boolean {
   if (
     pathname === '/' ||
@@ -21,26 +34,28 @@ function isKnownPathname(pathname: string): boolean {
 }
 
 export function useRouteGuards(pathname: string, authStatus: AuthStatus) {
-  useEffect(() => {
-    if (!isKnownPathname(pathname)) {
-      navigate('/', { replace: true })
-    }
-  }, [pathname])
+  const normalizedPathname = normalizePathname(pathname)
 
   useEffect(() => {
-    if (authStatus !== 'authenticated' && pathname !== '/') {
+    if (!isKnownPathname(normalizedPathname)) {
       navigate('/', { replace: true })
     }
-  }, [authStatus, pathname])
+  }, [normalizedPathname])
 
   useEffect(() => {
-    if (pathname === LEGACY_DRIVE_PATH) {
+    if (authStatus !== 'authenticated' && normalizedPathname !== '/') {
+      navigate('/', { replace: true })
+    }
+  }, [authStatus, normalizedPathname])
+
+  useEffect(() => {
+    if (normalizedPathname === LEGACY_DRIVE_PATH) {
       navigate(PROJECTS_ROOT_PATH, { replace: true })
       return
     }
 
-    if (authStatus === 'authenticated' && pathname === '/') {
+    if (authStatus === 'authenticated' && normalizedPathname === '/') {
       navigate(PROJECTS_ROOT_PATH, { replace: true })
     }
-  }, [authStatus, pathname])
+  }, [authStatus, normalizedPathname])
 }


### PR DESCRIPTION
## Summary
- normalize route guard path validation so project URLs with queries are treated as known paths
- ensure unauthenticated redirects respect the normalized pathname for `/projects/{id}` routes
- document a manual regression check for project pages with query parameters

## Testing
- npm run lint *(fails: existing lint errors in FileUploader.tsx and ProjectManagementPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f5fdf0408330b73eae473984243e