### PR TITLE
Normalize project route handling with query parameters

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,3 +67,11 @@ export default defineConfig([
   },
 ])
 ```
+
+## Regression verification
+
+To confirm that project routes with query parameters remain accessible:
+
+1. Sign in to the application.
+2. Navigate directly to a project detail page such as `/projects/123?name=demo` using the address bar or an internal link.
+3. Verify that you remain on the project management view (rather than being redirected back to `/projects`) and that reloading the page preserves the view.

--- a/frontend/src/app/routing/normalizePathname.ts
+++ b/frontend/src/app/routing/normalizePathname.ts
@@ -1,0 +1,12 @@
+export function normalizePathname(pathname: string): string {
+  if (!pathname) {
+    return '/'
+  }
+
+  const [normalized] = pathname.split(/[?#]/)
+  if (!normalized) {
+    return '/'
+  }
+
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}

--- a/frontend/src/app/routing/resolvePage.tsx
+++ b/frontend/src/app/routing/resolvePage.tsx
@@ -5,6 +5,7 @@ import { DriveSetupPage } from '../../pages/DriveSetupPage'
 import { LoginPage } from '../../pages/LoginPage'
 import { ProjectManagementPage } from '../../pages/ProjectManagementPage'
 import { PromptAdminPage } from '../../pages/PromptAdminPage'
+import { normalizePathname } from './normalizePathname'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/([^/]+)$/
 const PROJECTS_ROOT_PATH = '/projects'
@@ -17,19 +18,21 @@ interface ResolvePageOptions {
 }
 
 export function resolvePage({ pathname, authStatus }: ResolvePageOptions): ReactNode {
+  const normalizedPathname = normalizePathname(pathname)
+
   if (authStatus !== 'authenticated') {
     return <LoginPage />
   }
 
-  if (pathname === PROJECTS_ROOT_PATH || pathname === LEGACY_DRIVE_PATH) {
+  if (normalizedPathname === PROJECTS_ROOT_PATH || normalizedPathname === LEGACY_DRIVE_PATH) {
     return <DriveSetupPage />
   }
 
-  if (pathname === PROMPT_ADMIN_PATH) {
+  if (normalizedPathname === PROMPT_ADMIN_PATH) {
     return <PromptAdminPage />
   }
 
-  const projectMatch = pathname.match(PROJECT_PATH_PATTERN)
+  const projectMatch = normalizedPathname.match(PROJECT_PATH_PATTERN)
   if (projectMatch) {
     return <ProjectManagementPage projectId={decodeURIComponent(projectMatch[1])} />
   }

--- a/frontend/src/app/routing/useRouteGuards.ts
+++ b/frontend/src/app/routing/useRouteGuards.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import type { AuthStatus } from '../../auth'
 import { navigate } from '../../navigation'
+import { normalizePathname } from './normalizePathname'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/(.+)$/
 const PROJECTS_ROOT_PATH = '/projects'
@@ -21,26 +22,28 @@ function isKnownPathname(pathname: string): boolean {
 }
 
 export function useRouteGuards(pathname: string, authStatus: AuthStatus) {
-  useEffect(() => {
-    if (!isKnownPathname(pathname)) {
-      navigate('/', { replace: true })
-    }
-  }, [pathname])
+  const normalizedPathname = normalizePathname(pathname)
 
   useEffect(() => {
-    if (authStatus !== 'authenticated' && pathname !== '/') {
+    if (!isKnownPathname(normalizedPathname)) {
       navigate('/', { replace: true })
     }
-  }, [authStatus, pathname])
+  }, [normalizedPathname])
 
   useEffect(() => {
-    if (pathname === LEGACY_DRIVE_PATH) {
+    if (authStatus !== 'authenticated' && normalizedPathname !== '/') {
+      navigate('/', { replace: true })
+    }
+  }, [authStatus, normalizedPathname])
+
+  useEffect(() => {
+    if (normalizedPathname === LEGACY_DRIVE_PATH) {
       navigate(PROJECTS_ROOT_PATH, { replace: true })
       return
     }
 
-    if (authStatus === 'authenticated' && pathname === '/') {
+    if (authStatus === 'authenticated' && normalizedPathname === '/') {
       navigate(PROJECTS_ROOT_PATH, { replace: true })
     }
-  }, [authStatus, pathname])
+  }, [authStatus, normalizedPathname])
 }


### PR DESCRIPTION
## Summary
- normalize route guard path validation so project URLs with queries are treated as known paths
- ensure unauthenticated redirects respect the normalized pathname for `/projects/{id}` routes
- reuse the same pathname normalization in page resolution so project detail views load even when queries are present
- document a manual regression check for project pages with query parameters

## Testing
- npm run lint *(fails: existing lint errors in FileUploader.tsx and ProjectManagementPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f5fdf0408330b73eae473984243e