### PR TITLE
Fix file uploader configuration to avoid runtime errors

### DIFF
--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -38,6 +38,9 @@ interface MenuItemContent {
   buttonLabel: string
   allowedTypes: FileType[]
   requiredDocuments?: RequiredDocument[]
+  uploaderVariant?: 'default' | 'grid'
+  maxFiles?: number
+  hideDropzoneWhenFilled?: boolean
 }
 
 type GenerationStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -781,6 +784,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                     files={activeState.files}
                     onChange={(nextFiles) => handleChangeFiles(activeContent.id, nextFiles)}
                     disabled={activeState.status === 'loading'}
+                    maxFiles={activeContent.maxFiles}
+                    hideDropzoneWhenFilled={activeContent.hideDropzoneWhenFilled}
+                    variant={activeContent.uploaderVariant}
                   />
                 </section>
               )}


### PR DESCRIPTION
## Summary
- add optional max file count and variant handling to the FileUploader so configuration objects no longer trigger runtime reference errors
- allow project menu configuration to provide uploader options and forward them to the FileUploader component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e218f44320833095385e7bcf1e6c28