### PR TITLE
Add runtime prompt tuning controls

### DIFF
--- a/frontend/src/pages/AdminPromptsPage.css
+++ b/frontend/src/pages/AdminPromptsPage.css
@@ -208,8 +208,18 @@
   gap: clamp(0.85rem, 2vw, 1.25rem);
 }
 
+.admin-prompts__list-grid--section {
+  grid-template-columns: minmax(220px, 1fr) auto;
+  align-items: end;
+}
+
 .admin-prompts__list-grid--metadata {
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.admin-prompts__list-grid--builtin {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: end;
 }
 
 .admin-prompts__list-footer {
@@ -218,6 +228,11 @@
   gap: 1rem;
   align-items: flex-start;
   justify-content: space-between;
+}
+
+.admin-prompts__list-footer--wrap {
+  justify-content: flex-start;
+  gap: 0.75rem 1.25rem;
 }
 
 .admin-prompts__checkbox {
@@ -235,12 +250,78 @@
   accent-color: #2563eb;
 }
 
+.admin-prompts__switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.admin-prompts__switch input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: #2563eb;
+}
+
 .admin-prompts__notes {
   flex: 1;
   min-width: 220px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.admin-prompts__field--inline {
+  min-width: 180px;
+}
+
+.admin-prompts__select {
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.85);
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.admin-prompts__select:focus-visible {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  background: rgba(255, 255, 255, 0.98);
+}
+
+.admin-prompts__help {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.6;
+  color: #64748b;
+}
+
+.admin-prompts__preview {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.03);
+  padding: 1.25rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.admin-prompts__preview pre {
+  margin: 0;
+  font-family: 'Fira Code', 'Pretendard', monospace;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: #1e293b;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.admin-prompts__grid--metrics {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .admin-prompts__remove {
@@ -342,6 +423,11 @@
   }
 
   .admin-prompts__list-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-prompts__list-grid--section,
+  .admin-prompts__list-grid--builtin {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/pages/AdminPromptsPage.tsx
+++ b/frontend/src/pages/AdminPromptsPage.tsx
@@ -29,6 +29,40 @@ interface PromptMetadataEntry {
   value: string
 }
 
+interface PromptSection {
+  id: string
+  label: string
+  content: string
+  enabled: boolean
+}
+
+interface PromptScaffolding {
+  attachmentsHeading: string
+  attachmentsIntro: string
+  closingNote: string
+  formatWarning: string
+}
+
+type BuiltinContextRenderMode = 'file' | 'image' | 'text'
+
+interface BuiltinContext {
+  id: string
+  label: string
+  description: string
+  sourcePath: string
+  renderMode: BuiltinContextRenderMode
+  includeInPrompt: boolean
+  showInAttachmentList: boolean
+}
+
+interface ModelParameters {
+  temperature: number
+  topP: number
+  maxOutputTokens: number
+  presencePenalty: number
+  frequencyPenalty: number
+}
+
 interface PromptConfig {
   label: string
   summary: string
@@ -38,6 +72,11 @@ interface PromptConfig {
   evaluationNotes: string
   attachments: PromptAttachment[]
   metadata: PromptMetadataEntry[]
+  userPromptSections: PromptSection[]
+  scaffolding: PromptScaffolding
+  attachmentDescriptorTemplate: string
+  builtinContexts: BuiltinContext[]
+  modelParameters: ModelParameters
 }
 
 const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
@@ -90,6 +129,56 @@ const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
         value: 'markdown-table+summary',
       },
     ],
+    userPromptSections: [
+      {
+        id: 'feature-overview',
+        label: '분석 요청',
+        content:
+          '1. 첨부 자료에서 핵심 요구사항, 비즈니스 규칙, 화면 흐름을 추출한 뒤\n2. 기능을 대·중·소 분류 체계로 정리하고\n3. 근거가 된 원문이나 페이지 번호를 증빙 자료 열에 기재해 주세요.',
+        enabled: true,
+      },
+      {
+        id: 'feature-quality',
+        label: '품질 기준',
+        content:
+          '- 중복된 기능은 병합하고, 이름은 한글 명사형으로 통일합니다.\n- 기능 설명에는 “무엇을/왜”를 한 문장씩 포함하고, 정량 기준이 있다면 추가합니다.',
+        enabled: true,
+      },
+      {
+        id: 'feature-followup',
+        label: '후속 지시',
+        content:
+          'CSV에는 열 순서를 “대분류, 중분류, 소분류, 기능명, 기능설명, 근거자료”로 고정하고, 추가 제안은 별도 Markdown 섹션으로 출력하세요.',
+        enabled: true,
+      },
+    ],
+    scaffolding: {
+      attachmentsHeading: '첨부 파일 목록',
+      attachmentsIntro: '이번 요청에 포함된 참고 자료입니다. 파일별로 어떤 역할인지 명확히 이해하고 활용해 주세요.',
+      closingNote:
+        '위 자료는 신규 프로젝트 기능리스트 작성을 위한 참고 자료입니다. 누락된 영역이 보이면 추가 제안 섹션에 적어 주세요.',
+      formatWarning: '⚠️ 결과물은 반드시 CSV 구조를 준수해야 하며, 다른 파일 형식이나 자연어 단락으로 대체하지 마세요.',
+    },
+    attachmentDescriptorTemplate:
+      '{{index}}. {{label}} ({{extension}}) — {{description}}{{notesLine}}',
+    builtinContexts: [
+      {
+        id: 'feature-template',
+        label: '기능리스트 예제 양식',
+        description: '내장된 기능리스트 예제 XLSX를 PDF로 변환한 자료. 열 구성 및 표기 예시 참고용.',
+        sourcePath: 'template/가.계획/GS-B-XX-XXXX 기능리스트 v1.0.xlsx',
+        renderMode: 'file',
+        includeInPrompt: true,
+        showInAttachmentList: true,
+      },
+    ],
+    modelParameters: {
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 1600,
+      presencePenalty: 0,
+      frequencyPenalty: 0,
+    },
   },
   'testcase-generation': {
     label: '테스트케이스 생성',
@@ -101,6 +190,22 @@ const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
     evaluationNotes: '',
     attachments: [],
     metadata: [],
+    userPromptSections: [],
+    scaffolding: {
+      attachmentsHeading: '',
+      attachmentsIntro: '',
+      closingNote: '',
+      formatWarning: '',
+    },
+    attachmentDescriptorTemplate: '{{index}}. {{label}}',
+    builtinContexts: [],
+    modelParameters: {
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 1200,
+      presencePenalty: 0,
+      frequencyPenalty: 0,
+    },
   },
   'defect-report': {
     label: '결함 리포트',
@@ -112,6 +217,22 @@ const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
     evaluationNotes: '',
     attachments: [],
     metadata: [],
+    userPromptSections: [],
+    scaffolding: {
+      attachmentsHeading: '',
+      attachmentsIntro: '',
+      closingNote: '',
+      formatWarning: '',
+    },
+    attachmentDescriptorTemplate: '{{index}}. {{label}}',
+    builtinContexts: [],
+    modelParameters: {
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 1200,
+      presencePenalty: 0,
+      frequencyPenalty: 0,
+    },
   },
   'security-report': {
     label: '보안성 리포트',
@@ -123,6 +244,22 @@ const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
     evaluationNotes: '',
     attachments: [],
     metadata: [],
+    userPromptSections: [],
+    scaffolding: {
+      attachmentsHeading: '',
+      attachmentsIntro: '',
+      closingNote: '',
+      formatWarning: '',
+    },
+    attachmentDescriptorTemplate: '{{index}}. {{label}}',
+    builtinContexts: [],
+    modelParameters: {
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 1200,
+      presencePenalty: 0,
+      frequencyPenalty: 0,
+    },
   },
   'performance-report': {
     label: '성능 평가 리포트',
@@ -134,6 +271,22 @@ const INITIAL_PROMPTS: Record<PromptCategory, PromptConfig> = {
     evaluationNotes: '',
     attachments: [],
     metadata: [],
+    userPromptSections: [],
+    scaffolding: {
+      attachmentsHeading: '',
+      attachmentsIntro: '',
+      closingNote: '',
+      formatWarning: '',
+    },
+    attachmentDescriptorTemplate: '{{index}}. {{label}}',
+    builtinContexts: [],
+    modelParameters: {
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 1200,
+      presencePenalty: 0,
+      frequencyPenalty: 0,
+    },
   },
 }
 
@@ -145,11 +298,31 @@ function cloneMetadataEntry(entry: PromptMetadataEntry): PromptMetadataEntry {
   return { ...entry }
 }
 
+function cloneSection(section: PromptSection): PromptSection {
+  return { ...section }
+}
+
+function cloneScaffolding(scaffolding: PromptScaffolding): PromptScaffolding {
+  return { ...scaffolding }
+}
+
+function cloneBuiltinContext(context: BuiltinContext): BuiltinContext {
+  return { ...context }
+}
+
+function cloneModelParameters(parameters: ModelParameters): ModelParameters {
+  return { ...parameters }
+}
+
 function cloneConfig(config: PromptConfig): PromptConfig {
   return {
     ...config,
     attachments: config.attachments.map(cloneAttachment),
     metadata: config.metadata.map(cloneMetadataEntry),
+    userPromptSections: config.userPromptSections.map(cloneSection),
+    scaffolding: cloneScaffolding(config.scaffolding),
+    builtinContexts: config.builtinContexts.map(cloneBuiltinContext),
+    modelParameters: cloneModelParameters(config.modelParameters),
   }
 }
 
@@ -183,6 +356,84 @@ export function AdminPromptsPage() {
       })),
     [configs],
   )
+
+  const previewPrompt = useMemo(() => {
+    const segments: string[] = []
+
+    const base = activeConfig.userPrompt.trim()
+    if (base) {
+      segments.push(base)
+    }
+
+    activeConfig.userPromptSections
+      .filter((section) => section.enabled)
+      .forEach((section) => {
+        const label = section.label.trim()
+        const content = section.content.trim()
+        if (!label && !content) {
+          return
+        }
+        if (label && content) {
+          segments.push(`${label}\n${content}`)
+        } else {
+          segments.push(label || content)
+        }
+      })
+
+    const heading = activeConfig.scaffolding.attachmentsHeading.trim()
+    if (heading) {
+      segments.push(heading)
+    }
+
+    const intro = activeConfig.scaffolding.attachmentsIntro.trim()
+    if (intro) {
+      segments.push(intro)
+    }
+
+    const descriptorTemplate = activeConfig.attachmentDescriptorTemplate || '{{index}}. {{label}}'
+    const descriptorLines = activeConfig.attachments.map((attachment, index) => {
+      const extension = attachment.acceptedTypes.split(',')[0]?.trim() || '자료'
+      const notesLine = attachment.notes ? `\n   비고: ${attachment.notes}` : ''
+      return descriptorTemplate
+        .replaceAll('{{index}}', String(index + 1))
+        .replaceAll('{{label}}', attachment.label || '첨부 자료')
+        .replaceAll('{{description}}', attachment.description || '')
+        .replaceAll('{{extension}}', extension)
+        .replaceAll('{{notes}}', attachment.notes ?? '')
+        .replaceAll('{{notesLine}}', notesLine)
+    })
+
+    const builtinLines = activeConfig.builtinContexts
+      .filter((context) => context.showInAttachmentList)
+      .map((context, index) => {
+        const templateIndex = descriptorLines.length + index + 1
+        return descriptorTemplate
+          .replaceAll('{{index}}', String(templateIndex))
+          .replaceAll('{{label}}', context.label || '내장 컨텍스트')
+          .replaceAll('{{description}}', context.description || '')
+          .replaceAll('{{extension}}', context.renderMode === 'image' ? '이미지' : 'PDF')
+          .replaceAll('{{notes}}', context.sourcePath)
+          .replaceAll('{{notesLine}}', context.sourcePath ? `\n   경로: ${context.sourcePath}` : '')
+      })
+
+    const combinedDescriptorLines = [...descriptorLines, ...builtinLines]
+
+    if (combinedDescriptorLines.length > 0) {
+      segments.push(combinedDescriptorLines.join('\n'))
+    }
+
+    const closing = activeConfig.scaffolding.closingNote.trim()
+    if (closing) {
+      segments.push(closing)
+    }
+
+    const warning = activeConfig.scaffolding.formatWarning.trim()
+    if (warning) {
+      segments.push(warning)
+    }
+
+    return segments.join('\n\n').trim()
+  }, [activeConfig])
 
   const handleUpdateField = (field: keyof Pick<PromptConfig, 'requestDescription' | 'systemPrompt' | 'userPrompt' | 'evaluationNotes'>, value: string) => {
     setConfigs((prev) => ({
@@ -320,6 +571,201 @@ export function AdminPromptsPage() {
     setStatus({ category: null, type: 'idle', message: '' })
   }
 
+  const handleUpdateSection = (
+    sectionId: string,
+    field: keyof Pick<PromptSection, 'label' | 'content'>,
+    value: string,
+  ) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextSections = current.userPromptSections.map((section) =>
+        section.id === sectionId ? { ...section, [field]: value } : section,
+      )
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          userPromptSections: nextSections,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleToggleSectionEnabled = (sectionId: string, enabled: boolean) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextSections = current.userPromptSections.map((section) =>
+        section.id === sectionId ? { ...section, enabled } : section,
+      )
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          userPromptSections: nextSections,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleRemoveSection = (sectionId: string) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextSections = current.userPromptSections.filter((section) => section.id !== sectionId)
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          userPromptSections: nextSections,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleAddSection = () => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const newSection: PromptSection = {
+        id: createUniqueId(`${activeCategory}-section`),
+        label: '새 지침 구간',
+        content: '',
+        enabled: true,
+      }
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          userPromptSections: [...current.userPromptSections, newSection],
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleUpdateScaffolding = (
+    field: keyof PromptScaffolding,
+    value: string,
+  ) => {
+    setConfigs((prev) => ({
+      ...prev,
+      [activeCategory]: {
+        ...prev[activeCategory],
+        scaffolding: {
+          ...prev[activeCategory].scaffolding,
+          [field]: value,
+        },
+      },
+    }))
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleUpdateDescriptorTemplate = (value: string) => {
+    setConfigs((prev) => ({
+      ...prev,
+      [activeCategory]: {
+        ...prev[activeCategory],
+        attachmentDescriptorTemplate: value,
+      },
+    }))
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleUpdateBuiltinContext = <K extends keyof Pick<
+    BuiltinContext,
+    'label' | 'description' | 'sourcePath' | 'renderMode'
+  >>(contextId: string, field: K, value: BuiltinContext[K]) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextContexts = current.builtinContexts.map((context) =>
+        context.id === contextId ? { ...context, [field]: value } : context,
+      )
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          builtinContexts: nextContexts,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleToggleBuiltinContext = (
+    contextId: string,
+    field: keyof Pick<BuiltinContext, 'includeInPrompt' | 'showInAttachmentList'>,
+    value: boolean,
+  ) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextContexts = current.builtinContexts.map((context) =>
+        context.id === contextId ? { ...context, [field]: value } : context,
+      )
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          builtinContexts: nextContexts,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleRemoveBuiltinContext = (contextId: string) => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const nextContexts = current.builtinContexts.filter((context) => context.id !== contextId)
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          builtinContexts: nextContexts,
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleAddBuiltinContext = () => {
+    setConfigs((prev) => {
+      const current = prev[activeCategory]
+      const newContext: BuiltinContext = {
+        id: createUniqueId(`${activeCategory}-builtin`),
+        label: '새 내장 컨텍스트',
+        description: '',
+        sourcePath: '',
+        renderMode: 'file',
+        includeInPrompt: true,
+        showInAttachmentList: false,
+      }
+      return {
+        ...prev,
+        [activeCategory]: {
+          ...current,
+          builtinContexts: [...current.builtinContexts, newContext],
+        },
+      }
+    })
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
+  const handleUpdateModelParameters = <K extends keyof ModelParameters>(field: K, value: number) => {
+    const nextValue = Number.isFinite(value) ? value : 0
+    setConfigs((prev) => ({
+      ...prev,
+      [activeCategory]: {
+        ...prev[activeCategory],
+        modelParameters: {
+          ...prev[activeCategory].modelParameters,
+          [field]: nextValue,
+        },
+      },
+    }))
+    setStatus({ category: null, type: 'idle', message: '' })
+  }
+
   const handleSave = () => {
     setStatus({
       category: activeCategory,
@@ -431,6 +877,148 @@ export function AdminPromptsPage() {
               />
             </div>
 
+            <section className="admin-prompts__group" aria-labelledby="sections-title">
+              <div className="admin-prompts__group-header">
+                <h3 id="sections-title" className="admin-prompts__group-title">
+                  사용자 프롬프트 세부 지침
+                </h3>
+                <button type="button" className="admin-prompts__secondary" onClick={handleAddSection}>
+                  지침 블록 추가
+                </button>
+              </div>
+              {activeConfig.userPromptSections.length > 0 ? (
+                <ul className="admin-prompts__list">
+                  {activeConfig.userPromptSections.map((section) => (
+                    <li key={section.id} className="admin-prompts__list-item">
+                      <div className="admin-prompts__list-grid admin-prompts__list-grid--section">
+                        <div className="admin-prompts__field">
+                          <label className="admin-prompts__label" htmlFor={`${section.id}-label`}>
+                            구간 제목
+                          </label>
+                          <input
+                            id={`${section.id}-label`}
+                            type="text"
+                            className="admin-prompts__input"
+                            value={section.label}
+                            onChange={(event) => handleUpdateSection(section.id, 'label', event.target.value)}
+                          />
+                        </div>
+                        <label className="admin-prompts__switch">
+                          <input
+                            type="checkbox"
+                            checked={section.enabled}
+                            onChange={(event) => handleToggleSectionEnabled(section.id, event.target.checked)}
+                          />
+                          사용
+                        </label>
+                      </div>
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor={`${section.id}-content`}>
+                          지침 내용
+                        </label>
+                        <textarea
+                          id={`${section.id}-content`}
+                          className="admin-prompts__textarea"
+                          rows={4}
+                          value={section.content}
+                          onChange={(event) => handleUpdateSection(section.id, 'content', event.target.value)}
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        className="admin-prompts__remove"
+                        onClick={() => handleRemoveSection(section.id)}
+                      >
+                        삭제
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="admin-prompts__empty">아직 세부 지침이 없습니다. 필요한 지시를 추가해 주세요.</div>
+              )}
+            </section>
+
+            <section className="admin-prompts__group" aria-labelledby="scaffolding-title">
+              <h3 id="scaffolding-title" className="admin-prompts__group-title">
+                프롬프트 스캐폴딩
+              </h3>
+              <div className="admin-prompts__grid">
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="scaffolding-heading">
+                    첨부 목록 제목
+                  </label>
+                  <input
+                    id="scaffolding-heading"
+                    type="text"
+                    className="admin-prompts__input"
+                    value={activeConfig.scaffolding.attachmentsHeading}
+                    onChange={(event) => handleUpdateScaffolding('attachmentsHeading', event.target.value)}
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="scaffolding-intro">
+                    첨부 안내 문구
+                  </label>
+                  <textarea
+                    id="scaffolding-intro"
+                    className="admin-prompts__textarea"
+                    rows={3}
+                    value={activeConfig.scaffolding.attachmentsIntro}
+                    onChange={(event) => handleUpdateScaffolding('attachmentsIntro', event.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="admin-prompts__grid">
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="scaffolding-closing">
+                    마무리 안내 문장
+                  </label>
+                  <textarea
+                    id="scaffolding-closing"
+                    className="admin-prompts__textarea"
+                    rows={3}
+                    value={activeConfig.scaffolding.closingNote}
+                    onChange={(event) => handleUpdateScaffolding('closingNote', event.target.value)}
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="scaffolding-warning">
+                    형식 제한 경고
+                  </label>
+                  <textarea
+                    id="scaffolding-warning"
+                    className="admin-prompts__textarea"
+                    rows={3}
+                    value={activeConfig.scaffolding.formatWarning}
+                    onChange={(event) => handleUpdateScaffolding('formatWarning', event.target.value)}
+                  />
+                </div>
+              </div>
+            </section>
+
+            <section className="admin-prompts__group" aria-labelledby="descriptor-title">
+              <h3 id="descriptor-title" className="admin-prompts__group-title">
+                첨부 설명 포맷
+              </h3>
+              <div className="admin-prompts__field">
+                <label className="admin-prompts__label" htmlFor="descriptor-template">
+                  템플릿 문자열
+                </label>
+                <input
+                  id="descriptor-template"
+                  type="text"
+                  className="admin-prompts__input"
+                  value={activeConfig.attachmentDescriptorTemplate}
+                  onChange={(event) => handleUpdateDescriptorTemplate(event.target.value)}
+                  placeholder="예: {{index}}. {{label}} ({{extension}}) — {{description}}"
+                />
+              </div>
+              <p className="admin-prompts__help">
+                {'사용 가능한 플레이스홀더: {{index}}, {{label}}, {{description}}, {{extension}}, {{notes}}, {{notesLine}}'}
+              </p>
+            </section>
+
             <section className="admin-prompts__group" aria-labelledby="attachments-title">
               <div className="admin-prompts__group-header">
                 <h3 id="attachments-title" className="admin-prompts__group-title">
@@ -536,6 +1124,121 @@ export function AdminPromptsPage() {
               )}
             </section>
 
+            <section className="admin-prompts__group" aria-labelledby="builtin-title">
+              <div className="admin-prompts__group-header">
+                <h3 id="builtin-title" className="admin-prompts__group-title">
+                  내장 컨텍스트
+                </h3>
+                <button type="button" className="admin-prompts__secondary" onClick={handleAddBuiltinContext}>
+                  컨텍스트 추가
+                </button>
+              </div>
+              {activeConfig.builtinContexts.length > 0 ? (
+                <ul className="admin-prompts__list">
+                  {activeConfig.builtinContexts.map((context) => (
+                    <li key={context.id} className="admin-prompts__list-item">
+                      <div className="admin-prompts__list-grid admin-prompts__list-grid--builtin">
+                        <div className="admin-prompts__field">
+                          <label className="admin-prompts__label" htmlFor={`${context.id}-label`}>
+                            이름
+                          </label>
+                          <input
+                            id={`${context.id}-label`}
+                            type="text"
+                            className="admin-prompts__input"
+                            value={context.label}
+                            onChange={(event) => handleUpdateBuiltinContext(context.id, 'label', event.target.value)}
+                          />
+                        </div>
+                        <div className="admin-prompts__field">
+                          <label className="admin-prompts__label" htmlFor={`${context.id}-source`}>
+                            참조 경로 또는 설명
+                          </label>
+                          <input
+                            id={`${context.id}-source`}
+                            type="text"
+                            className="admin-prompts__input"
+                            value={context.sourcePath}
+                            onChange={(event) => handleUpdateBuiltinContext(context.id, 'sourcePath', event.target.value)}
+                            placeholder="예: template/... 또는 외부 링크"
+                          />
+                        </div>
+                      </div>
+
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor={`${context.id}-description`}>
+                          설명
+                        </label>
+                        <textarea
+                          id={`${context.id}-description`}
+                          className="admin-prompts__textarea"
+                          rows={3}
+                          value={context.description}
+                          onChange={(event) => handleUpdateBuiltinContext(context.id, 'description', event.target.value)}
+                        />
+                      </div>
+
+                      <div className="admin-prompts__list-footer admin-prompts__list-footer--wrap">
+                        <div className="admin-prompts__field admin-prompts__field--inline">
+                          <label className="admin-prompts__label" htmlFor={`${context.id}-render`}>
+                            렌더링 방식
+                          </label>
+                          <select
+                            id={`${context.id}-render`}
+                            className="admin-prompts__select"
+                            value={context.renderMode}
+                            onChange={(event) =>
+                              handleUpdateBuiltinContext(
+                                context.id,
+                                'renderMode',
+                                event.target.value as BuiltinContextRenderMode,
+                              )
+                            }
+                          >
+                            <option value="file">파일</option>
+                            <option value="image">이미지</option>
+                            <option value="text">텍스트</option>
+                          </select>
+                        </div>
+
+                        <label className="admin-prompts__switch">
+                          <input
+                            type="checkbox"
+                            checked={context.includeInPrompt}
+                            onChange={(event) =>
+                              handleToggleBuiltinContext(context.id, 'includeInPrompt', event.target.checked)
+                            }
+                          />
+                          모델에 전달
+                        </label>
+
+                        <label className="admin-prompts__switch">
+                          <input
+                            type="checkbox"
+                            checked={context.showInAttachmentList}
+                            onChange={(event) =>
+                              handleToggleBuiltinContext(context.id, 'showInAttachmentList', event.target.checked)
+                            }
+                          />
+                          첨부 목록에 노출
+                        </label>
+
+                        <button
+                          type="button"
+                          className="admin-prompts__remove"
+                          onClick={() => handleRemoveBuiltinContext(context.id)}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="admin-prompts__empty">등록된 내장 컨텍스트가 없습니다. 필요 시 추가하세요.</div>
+              )}
+            </section>
+
             <section className="admin-prompts__group" aria-labelledby="metadata-title">
               <div className="admin-prompts__group-header">
                 <h3 id="metadata-title" className="admin-prompts__group-title">
@@ -592,6 +1295,108 @@ export function AdminPromptsPage() {
               ) : (
                 <div className="admin-prompts__empty">추가 메타데이터가 없습니다. 필요 시 항목을 추가하세요.</div>
               )}
+            </section>
+
+            <section className="admin-prompts__group" aria-labelledby="model-params-title">
+              <h3 id="model-params-title" className="admin-prompts__group-title">
+                모델 파라미터
+              </h3>
+              <div className="admin-prompts__grid admin-prompts__grid--metrics">
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="param-temperature">
+                    Temperature
+                  </label>
+                  <input
+                    id="param-temperature"
+                    type="number"
+                    step={0.1}
+                    min={0}
+                    max={2}
+                    className="admin-prompts__input"
+                    value={activeConfig.modelParameters.temperature}
+                    onChange={(event) =>
+                      handleUpdateModelParameters('temperature', Number(event.target.value))
+                    }
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="param-top-p">
+                    Top P
+                  </label>
+                  <input
+                    id="param-top-p"
+                    type="number"
+                    step={0.05}
+                    min={0}
+                    max={1}
+                    className="admin-prompts__input"
+                    value={activeConfig.modelParameters.topP}
+                    onChange={(event) => handleUpdateModelParameters('topP', Number(event.target.value))}
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="param-max-tokens">
+                    최대 출력 토큰
+                  </label>
+                  <input
+                    id="param-max-tokens"
+                    type="number"
+                    step={50}
+                    min={0}
+                    className="admin-prompts__input"
+                    value={activeConfig.modelParameters.maxOutputTokens}
+                    onChange={(event) =>
+                      handleUpdateModelParameters('maxOutputTokens', Number(event.target.value))
+                    }
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="param-presence">
+                    Presence penalty
+                  </label>
+                  <input
+                    id="param-presence"
+                    type="number"
+                    step={0.1}
+                    min={-2}
+                    max={2}
+                    className="admin-prompts__input"
+                    value={activeConfig.modelParameters.presencePenalty}
+                    onChange={(event) =>
+                      handleUpdateModelParameters('presencePenalty', Number(event.target.value))
+                    }
+                  />
+                </div>
+                <div className="admin-prompts__field">
+                  <label className="admin-prompts__label" htmlFor="param-frequency">
+                    Frequency penalty
+                  </label>
+                  <input
+                    id="param-frequency"
+                    type="number"
+                    step={0.1}
+                    min={-2}
+                    max={2}
+                    className="admin-prompts__input"
+                    value={activeConfig.modelParameters.frequencyPenalty}
+                    onChange={(event) =>
+                      handleUpdateModelParameters('frequencyPenalty', Number(event.target.value))
+                    }
+                  />
+                </div>
+              </div>
+            </section>
+
+            <section className="admin-prompts__group" aria-labelledby="preview-title">
+              <h3 id="preview-title" className="admin-prompts__group-title">
+                사용자 프롬프트 미리보기
+              </h3>
+              <div className="admin-prompts__preview" role="presentation">
+                <pre>{previewPrompt || '구성된 프롬프트가 여기에 표시됩니다.'}</pre>
+              </div>
+              <p className="admin-prompts__help">
+                첨부 설명 미리보기는 현재 요구 첨부 항목과 내장 컨텍스트 설정을 기준으로 표시됩니다.
+              </p>
             </section>
 
             {status.category === activeCategory && status.message && (


### PR DESCRIPTION
## Summary
- extend the prompt admin config to support user prompt sections, scaffolding strings, attachment descriptor templates, built-in contexts, and model parameters
- add rich editing controls, toggles, and preview blocks so admins can adjust prompt pieces at runtime without code changes
- refresh the page styling to accommodate the new management panels and switches

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25c38412c833096dc9ee48e5c82f1