### PR TITLE
Add runtime prompt configuration service and admin UI wiring

### DIFF
--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .container import Container
-from .routes import auth_router, drive_router
+from .routes import auth_router, drive_router, prompt_router
 
 
 def create_app() -> FastAPI:
@@ -28,6 +28,7 @@ def create_app() -> FastAPI:
 
     app.include_router(auth_router)
     app.include_router(drive_router)
+    app.include_router(prompt_router)
 
     @app.get("/")
     def read_root() -> dict[str, str]:

--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .config import Settings, load_settings
 from .services.ai_generation import AIGenerationService
+from .services.prompt_config import PromptConfigService
 from .services.google_drive import GoogleDriveService
 from .services.oauth import GoogleOAuthService
 from .token_store import TokenStorage
@@ -17,7 +18,11 @@ class Container:
         self._drive_service = GoogleDriveService(
             self._settings, self._token_storage, self._oauth_service
         )
-        self._ai_generation_service = AIGenerationService(self._settings)
+        prompt_storage_path = self._settings.tokens_path.with_name("prompt_configs.json")
+        self._prompt_config_service = PromptConfigService(prompt_storage_path)
+        self._ai_generation_service = AIGenerationService(
+            self._settings, self._prompt_config_service
+        )
 
     @property
     def settings(self) -> Settings:
@@ -38,3 +43,7 @@ class Container:
     @property
     def ai_generation_service(self) -> AIGenerationService:
         return self._ai_generation_service
+
+    @property
+    def prompt_config_service(self) -> PromptConfigService:
+        return self._prompt_config_service

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -5,6 +5,7 @@ from fastapi import Depends, Request
 from .container import Container
 from .services.ai_generation import AIGenerationService
 from .services.google_drive import GoogleDriveService
+from .services.prompt_config import PromptConfigService
 from .services.oauth import GoogleOAuthService
 from .token_store import TokenStorage
 
@@ -32,3 +33,9 @@ def get_ai_generation_service(
     container: Container = Depends(get_container),
 ) -> AIGenerationService:
     return container.ai_generation_service
+
+
+def get_prompt_config_service(
+    container: Container = Depends(get_container),
+) -> PromptConfigService:
+    return container.prompt_config_service

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,4 +1,5 @@
 from .auth import router as auth_router
 from .drive import router as drive_router
+from .prompts import router as prompt_router
 
-__all__ = ["auth_router", "drive_router"]
+__all__ = ["auth_router", "drive_router", "prompt_router"]

--- a/backend/app/routes/prompts.py
+++ b/backend/app/routes/prompts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..dependencies import get_prompt_config_service
+from ..services.prompt_config import PromptConfig, PromptConfigService
+
+router = APIRouter(prefix="/admin/prompts", tags=["prompt-config"])
+
+
+@router.get("", response_model=None)
+def list_prompt_configs(
+    prompt_service: PromptConfigService = Depends(get_prompt_config_service),
+) -> Dict[str, Dict[str, Dict]]:
+    configs = prompt_service.list_configs()
+    defaults = prompt_service.get_defaults()
+    return {
+        "current": {
+            key: config.model_dump(mode="json", by_alias=True)
+            for key, config in configs.items()
+        },
+        "defaults": defaults,
+    }
+
+
+@router.get("/{menu_id}")
+def get_prompt_config(
+    menu_id: str,
+    prompt_service: PromptConfigService = Depends(get_prompt_config_service),
+) -> Dict[str, Dict]:
+    try:
+        config = prompt_service.get_config(menu_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="알 수 없는 메뉴입니다.") from exc
+    return {"config": config.model_dump(mode="json", by_alias=True)}
+
+
+@router.put("/{menu_id}")
+def update_prompt_config(
+    menu_id: str,
+    payload: PromptConfig,
+    prompt_service: PromptConfigService = Depends(get_prompt_config_service),
+) -> Dict[str, Dict]:
+    try:
+        updated = prompt_service.update_config(
+            menu_id, payload.model_dump(mode="json", by_alias=True)
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="알 수 없는 메뉴입니다.") from exc
+    return {"config": updated.model_dump(mode="json", by_alias=True)}

--- a/backend/app/services/prompt_config.py
+++ b/backend/app/services/prompt_config.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+RenderMode = Literal["file", "image", "xlsx-to-pdf", "text"]
+
+
+def _to_camel(value: str) -> str:
+    parts = value.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+class PromptSection(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore", alias_generator=_to_camel, populate_by_name=True
+    )
+
+    id: str
+    label: str = ""
+    content: str = ""
+    enabled: bool = True
+
+
+class PromptScaffolding(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore", alias_generator=_to_camel, populate_by_name=True
+    )
+
+    attachments_heading: str = ""
+    attachments_intro: str = ""
+    closing_note: str = ""
+    format_warning: str = ""
+
+
+class PromptBuiltinContext(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore", alias_generator=_to_camel, populate_by_name=True
+    )
+
+    id: str
+    label: str = ""
+    description: str = ""
+    source_path: str = ""
+    render_mode: RenderMode = "file"
+    include_in_prompt: bool = True
+    show_in_attachment_list: bool = True
+
+
+class PromptModelParameters(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore", alias_generator=_to_camel, populate_by_name=True
+    )
+
+    temperature: float = 0.2
+    top_p: float = 0.9
+    max_output_tokens: int = 1500
+    presence_penalty: float = 0.0
+    frequency_penalty: float = 0.0
+
+
+class PromptConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore", alias_generator=_to_camel, populate_by_name=True
+    )
+
+    label: str
+    summary: str = ""
+    request_description: str = ""
+    system_prompt: str
+    user_prompt: str = ""
+    evaluation_notes: str = ""
+    user_prompt_sections: List[PromptSection] = Field(default_factory=list)
+    scaffolding: PromptScaffolding = Field(default_factory=PromptScaffolding)
+    attachment_descriptor_template: str = "{{index}}. {{descriptor}}"
+    builtin_contexts: List[PromptBuiltinContext] = Field(default_factory=list)
+    model_parameters: PromptModelParameters = Field(default_factory=PromptModelParameters)
+
+
+@dataclass
+class _StoredPrompt:
+    menu_id: str
+    config: PromptConfig
+
+
+class PromptConfigStore:
+    """Persist prompt configuration to a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load_all(self) -> Dict[str, Any]:
+        try:
+            with self._path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError:
+            return {}
+
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    def save_all(self, payload: Mapping[str, Any]) -> None:
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+        temp_path = self._path.with_suffix(".tmp")
+        temp_path.write_text(serialized, encoding="utf-8")
+        temp_path.replace(self._path)
+
+    def save(self, menu_id: str, config: Mapping[str, Any]) -> None:
+        data = self.load_all()
+        data[menu_id] = config
+        self.save_all(data)
+
+
+def _merge_dict(base: Dict[str, Any], updates: Mapping[str, Any]) -> Dict[str, Any]:
+    for key, value in updates.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, Mapping)
+        ):
+            base[key] = _merge_dict(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+_DEFAULT_PROMPTS: Dict[str, PromptConfig] = {
+    "feature-list": PromptConfig(
+        label="기능리스트 생성",
+        summary="요구사항 문서를 기반으로 신규 프로젝트의 기능 정의서를 작성합니다.",
+        request_description="업로드된 자료에서 주요 기능과 근거를 추출하여 CSV로 정리합니다.",
+        system_prompt="당신은 소프트웨어 기획 QA 리드입니다. 업로드된 요구사항을 기반으로 기능 정의서를 작성합니다.",
+        user_prompt=(
+            "요구사항 자료에서 주요 기능을 발췌하여 CSV로 정리하세요. "
+            "다음 열을 포함해야 합니다: 대분류, 중분류, 소분류. "
+            "각 열은 템플릿의 계층 구조에 맞춰 핵심 기능을 요약해야 합니다."
+        ),
+        user_prompt_sections=[
+            PromptSection(
+                id="feature-analysis",
+                label="분석 요청",
+                content=(
+                    "1. 첨부 자료에서 핵심 요구사항, 비즈니스 규칙, 화면 흐름을 추출하고\n"
+                    "2. 기능을 대·중·소 분류 체계로 재구성하며\n"
+                    "3. 근거가 된 원문이나 페이지 번호를 증빙 자료 열에 기재하세요."
+                ),
+            ),
+            PromptSection(
+                id="feature-quality",
+                label="품질 기준",
+                content=(
+                    "- 중복된 기능은 병합하고, 이름은 한글 명사형으로 통일합니다.\n"
+                    "- 기능 설명에는 ‘무엇을/왜’를 한 문장씩 포함하고, 정량 기준이 있다면 추가합니다."
+                ),
+            ),
+            PromptSection(
+                id="feature-followup",
+                label="후속 지시",
+                content=(
+                    "CSV에는 열 순서를 ‘대분류, 중분류, 소분류, 기능명, 기능설명, 근거자료’로 고정하고, "
+                    "추가 제안은 별도 Markdown 섹션으로 출력하세요."
+                ),
+            ),
+        ],
+        scaffolding=PromptScaffolding(
+            attachments_heading="첨부 파일 목록",
+            attachments_intro=(
+                "다음 첨부 파일을 참고하여 요구사항을 분석하고 지침에 맞는 CSV를 작성하세요.\n"
+                "각 파일은 업로드된 순서대로 첨부되어 있습니다."
+            ),
+            closing_note="위 자료는 {{context_summary}}입니다. 이 자료를 활용하여 기능리스트를 작성해 주세요.",
+            format_warning="CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.",
+        ),
+        builtin_contexts=[
+            PromptBuiltinContext(
+                id="feature-template",
+                label="기능리스트 예제 양식",
+                description="내장된 기능리스트 예제 XLSX를 PDF로 변환한 자료. 열 구성 및 표기 예시 참고용.",
+                source_path="template/가.계획/GS-B-XX-XXXX 기능리스트 v1.0.xlsx",
+                render_mode="xlsx-to-pdf",
+                include_in_prompt=True,
+                show_in_attachment_list=True,
+            )
+        ],
+    ),
+    "testcase-generation": PromptConfig(
+        label="테스트케이스 생성",
+        summary="요구사항을 바탕으로 테스트 케이스 초안을 작성합니다.",
+        request_description="핵심 시나리오를 도출하고 CSV 포맷으로 정리합니다.",
+        system_prompt="당신은 소프트웨어 QA 테스터입니다. 업로드된 요구사항을 읽고 테스트 케이스 초안을 설계합니다.",
+        user_prompt=(
+            "요구사항을 분석하여 테스트 케이스를 CSV로 작성하세요. "
+            "다음 열을 포함합니다: 대분류, 중분류, 소분류, 테스트 케이스 ID, 테스트 시나리오, 입력(사전조건 포함), 기대 출력(사후조건 포함), 테스트 결과, 상세 테스트 결과, 비고. "
+            "테스트 케이스 ID는 TC-001과 같이 순차적으로 부여하고, 테스트 결과는 기본값으로 '미실행'을 사용하세요."
+        ),
+        scaffolding=PromptScaffolding(
+            attachments_heading="첨부 파일 목록",
+            attachments_intro=(
+                "다음 첨부 파일을 참고하여 요구사항을 분석한 뒤 지침에 맞는 테스트 케이스를 작성하세요."
+            ),
+            closing_note="위 자료는 {{context_summary}}입니다. 이 자료를 바탕으로 테스트케이스를 작성해 주세요.",
+            format_warning="CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.",
+        ),
+    ),
+    "defect-report": PromptConfig(
+        label="결함 리포트",
+        summary="테스트 로그와 증적 자료를 바탕으로 결함 요약을 생성합니다.",
+        request_description="핵심 결함을 선별해 CSV 테이블로 정리합니다.",
+        system_prompt="당신은 QA 분석가입니다. 업로드된 테스트 로그와 증적 자료를 바탕으로 결함 요약을 작성합니다.",
+        user_prompt=(
+            "자료를 분석해 주요 결함을 요약한 CSV를 작성하세요. 열은 결함 ID, 심각도, 발생 모듈, 현상 요약, 제안 조치입니다. "
+            "결함 ID는 BUG-001 형식을 사용하고, 심각도는 치명/중대/보통/경미 중 하나로 표기합니다."
+        ),
+        scaffolding=PromptScaffolding(
+            attachments_heading="첨부 파일 목록",
+            attachments_intro="참고 자료를 검토하여 결함을 정리하세요.",
+            format_warning="CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.",
+        ),
+    ),
+    "security-report": PromptConfig(
+        label="보안성 리포트",
+        summary="보안 점검 결과와 취약점 목록을 요약합니다.",
+        request_description="발견된 취약점을 위험도와 함께 정리합니다.",
+        system_prompt="당신은 보안 컨설턴트입니다. 업로드된 보안 점검 결과를 요약한 리포트를 만듭니다.",
+        user_prompt=(
+            "자료를 바탕으로 취약점을 정리한 CSV를 작성하세요. 열은 취약점 ID, 위험도, 영향 영역, 발견 내용, 권장 조치입니다. "
+            "위험도는 높음/중간/낮음 중 하나를 사용합니다."
+        ),
+        scaffolding=PromptScaffolding(
+            attachments_heading="첨부 파일 목록",
+            attachments_intro="다음 자료를 확인하고 취약점을 정리하세요.",
+            format_warning="CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.",
+        ),
+    ),
+    "performance-report": PromptConfig(
+        label="성능 평가 리포트",
+        summary="성능 측정 결과를 분석해 표로 정리합니다.",
+        request_description="중요 시나리오의 성능 수치를 정리합니다.",
+        system_prompt="당신은 성능 엔지니어입니다. 업로드된 성능 측정 자료를 분석하여 결과를 요약합니다.",
+        user_prompt=(
+            "자료를 분석하여 주요 시나리오의 성능을 정리한 CSV를 작성하세요. 열은 시나리오, 평균 응답(ms), 처리량(TPS), 자원 사용 요약, 개선 제안입니다."
+        ),
+        scaffolding=PromptScaffolding(
+            attachments_heading="첨부 파일 목록",
+            attachments_intro="관련 자료를 검토하여 성능 결과를 정리하세요.",
+            format_warning="CSV 이외의 다른 형식이나 설명 문장은 포함하지 마세요.",
+        ),
+    ),
+}
+
+
+class PromptConfigService:
+    """Load and persist prompt configuration for runtime use."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self._store = PromptConfigStore(storage_path)
+
+    def _default_configs(self) -> Dict[str, PromptConfig]:
+        return {key: value.model_copy(deep=True) for key, value in _DEFAULT_PROMPTS.items()}
+
+    def get_defaults(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            key: config.model_dump(mode="json", by_alias=True)
+            for key, config in self._default_configs().items()
+        }
+
+    def list_configs(self) -> Dict[str, PromptConfig]:
+        stored = self._store.load_all()
+        defaults = self._default_configs()
+        merged: Dict[str, PromptConfig] = {}
+        for menu_id, default_config in defaults.items():
+            raw = stored.get(menu_id)
+            base = default_config.model_dump(mode="json", by_alias=True)
+            if isinstance(raw, Mapping):
+                base = _merge_dict(base, raw)
+            merged[menu_id] = PromptConfig.model_validate(base)
+        return merged
+
+    def get_config(self, menu_id: str) -> PromptConfig:
+        configs = self.list_configs()
+        if menu_id not in configs:
+            raise KeyError(menu_id)
+        return configs[menu_id]
+
+    def update_config(self, menu_id: str, payload: Mapping[str, Any]) -> PromptConfig:
+        if menu_id not in _DEFAULT_PROMPTS:
+            raise KeyError(menu_id)
+        default_config = _DEFAULT_PROMPTS[menu_id]
+        base = default_config.model_dump(mode="json", by_alias=True)
+        merged = _merge_dict(base, payload)
+        validated = PromptConfig.model_validate(merged)
+        self._store.save(menu_id, validated.model_dump(mode="json", by_alias=True))
+        return validated
+
+    def get_runtime_prompt(self, menu_id: str) -> PromptConfig:
+        return self.get_config(menu_id)
+
+
+__all__ = [
+    "PromptConfig",
+    "PromptConfigService",
+    "PromptBuiltinContext",
+    "PromptModelParameters",
+    "PromptScaffolding",
+    "PromptSection",
+    "RenderMode",
+]

--- a/frontend/src/pages/AdminPromptsPage.css
+++ b/frontend/src/pages/AdminPromptsPage.css
@@ -1,356 +1,332 @@
 .admin-prompts {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 24px;
+  padding: 16px 0 48px;
+}
+
+.admin-prompts--loading,
+.admin-prompts--error {
+  gap: 32px;
+}
+
+.admin-prompts__placeholder {
+  padding: 48px;
+  border: 1px dashed var(--gray-300, #d1d5db);
+  border-radius: 12px;
+  text-align: center;
+  color: var(--gray-600, #4b5563);
+  background-color: var(--gray-50, #f9fafb);
+}
+
+.admin-prompts__placeholder--error {
+  border-color: var(--rose-300, #fda4af);
+  color: var(--rose-700, #be123c);
+  background-color: var(--rose-50, #fff1f2);
 }
 
 .admin-prompts__layout {
   display: grid;
-  grid-template-columns: minmax(220px, 280px) 1fr;
-  gap: clamp(1.75rem, 3vw, 2.75rem);
+  grid-template-columns: 240px 1fr;
+  gap: 24px;
+  align-items: start;
 }
 
 .admin-prompts__nav {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 8px;
 }
 
-.admin-prompts__nav-button {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.4rem;
-  width: 100%;
-  padding: 1.1rem 1.2rem;
-  border-radius: 18px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(241, 245, 249, 0.6);
-  color: #0f172a;
+.admin-prompts__nav-item {
   text-align: left;
-  font-size: 0.95rem;
-  font-weight: 600;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 10px;
+  background-color: var(--surface, #fff);
+  padding: 16px;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.admin-prompts__nav-button:hover,
-.admin-prompts__nav-button:focus-visible {
-  outline: none;
-  border-color: rgba(59, 130, 246, 0.55);
-  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.15);
-  transform: translateY(-2px);
-  background: rgba(59, 130, 246, 0.12);
+.admin-prompts__nav-item:hover,
+.admin-prompts__nav-item:focus-visible {
+  border-color: var(--primary-400, #60a5fa);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
 }
 
-.admin-prompts__nav-button--active {
-  border-color: rgba(59, 130, 246, 0.8);
-  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.25);
-  background: rgba(59, 130, 246, 0.18);
+.admin-prompts__nav-item--active {
+  border-color: var(--primary-500, #3b82f6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
 .admin-prompts__nav-label {
-  font-size: 1.02rem;
-  font-weight: 700;
+  display: block;
+  font-weight: 600;
+  color: var(--gray-900, #111827);
 }
 
 .admin-prompts__nav-summary {
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: #475569;
+  margin-top: 4px;
+  display: block;
+  color: var(--gray-600, #4b5563);
+  font-size: 0.875rem;
+  line-height: 1.4;
 }
 
 .admin-prompts__content {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  padding: clamp(1.5rem, 2.5vw, 2rem);
-  border-radius: 24px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  gap: 24px;
+  padding: 24px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 16px;
+  background-color: var(--surface, #fff);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
 }
 
-.admin-prompts__content-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.admin-prompts__content-title {
+.admin-prompts__title {
   margin: 0;
-  font-size: clamp(1.6rem, 1.4vw + 1.2rem, 2.2rem);
-  color: #0f172a;
+  font-size: 1.5rem;
   font-weight: 700;
+  color: var(--gray-900, #111827);
 }
 
-.admin-prompts__content-description {
+.admin-prompts__summary {
   margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: #475569;
+  color: var(--gray-600, #4b5563);
 }
 
 .admin-prompts__field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 8px;
+}
+
+.admin-prompts__field--half {
+  flex: 1 1 50%;
 }
 
 .admin-prompts__label {
   font-size: 0.9rem;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--gray-700, #374151);
 }
 
 .admin-prompts__input,
-.admin-prompts__textarea {
+.admin-prompts__textarea,
+.admin-prompts__select {
   width: 100%;
-  padding: 0.75rem 0.85rem;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 10px 12px;
+  border: 1px solid var(--gray-300, #d1d5db);
+  border-radius: 8px;
   font-size: 0.95rem;
-  background: rgba(248, 250, 252, 0.85);
-  color: #0f172a;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  resize: vertical;
-}
-
-.admin-prompts__input:focus-visible,
-.admin-prompts__textarea:focus-visible {
-  outline: none;
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
-  background: rgba(255, 255, 255, 0.98);
+  color: var(--gray-900, #111827);
+  background-color: var(--surface, #fff);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .admin-prompts__textarea {
   min-height: 96px;
+  resize: vertical;
 }
 
-.admin-prompts__grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(1rem, 1.5vw, 1.5rem);
+.admin-prompts__input:focus-visible,
+.admin-prompts__textarea:focus-visible,
+.admin-prompts__select:focus-visible {
+  outline: none;
+  border-color: var(--primary-500, #3b82f6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
 }
 
 .admin-prompts__group {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.5rem;
-  border-radius: 20px;
-  background: rgba(248, 250, 252, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 12px;
+  background-color: var(--gray-50, #f9fafb);
 }
 
 .admin-prompts__group-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 12px;
 }
 
 .admin-prompts__group-title {
   margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
-  color: #0f172a;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--gray-800, #1f2937);
 }
 
 .admin-prompts__secondary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(59, 130, 246, 0.5);
-  background: rgba(59, 130, 246, 0.1);
-  color: rgba(30, 64, 175, 0.95);
-  font-size: 0.9rem;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--primary-500, #3b82f6);
+  background: transparent;
+  color: var(--primary-600, #2563eb);
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 120ms ease, color 120ms ease;
 }
 
 .admin-prompts__secondary:hover,
 .admin-prompts__secondary:focus-visible {
+  background-color: rgba(37, 99, 235, 0.08);
   outline: none;
-  border-color: rgba(59, 130, 246, 0.75);
-  background: rgba(59, 130, 246, 0.18);
-  color: rgba(30, 64, 175, 1);
-  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.18);
 }
 
 .admin-prompts__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-}
-
-.admin-prompts__list--compact {
-  gap: 1rem;
+  gap: 16px;
 }
 
 .admin-prompts__list-item {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.1rem;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  gap: 12px;
+  padding: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--surface, #fff);
 }
 
-.admin-prompts__list-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(0.85rem, 2vw, 1.25rem);
-}
-
-.admin-prompts__list-grid--metadata {
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.admin-prompts__list-footer {
+.admin-prompts__list-row {
   display: flex;
+  align-items: center;
+  gap: 16px;
   flex-wrap: wrap;
-  gap: 1rem;
-  align-items: flex-start;
-  justify-content: space-between;
 }
 
-.admin-prompts__checkbox {
+.admin-prompts__switch {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 8px;
   font-size: 0.9rem;
-  font-weight: 600;
-  color: #0f172a;
+  color: var(--gray-700, #374151);
 }
 
-.admin-prompts__checkbox input[type='checkbox'] {
+.admin-prompts__switch input[type='checkbox'] {
   width: 18px;
   height: 18px;
-  accent-color: #2563eb;
-}
-
-.admin-prompts__notes {
-  flex: 1;
-  min-width: 220px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
 }
 
 .admin-prompts__remove {
-  align-self: flex-start;
-  padding: 0.4rem 0.9rem;
-  border-radius: 12px;
-  border: 1px solid rgba(248, 113, 113, 0.55);
-  background: rgba(248, 113, 113, 0.12);
-  color: rgba(185, 28, 28, 0.95);
-  font-size: 0.85rem;
-  font-weight: 600;
+  align-self: flex-end;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  background-color: var(--rose-500, #f43f5e);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 600;
 }
 
 .admin-prompts__remove:hover,
 .admin-prompts__remove:focus-visible {
+  background-color: var(--rose-600, #e11d48);
   outline: none;
-  border-color: rgba(248, 113, 113, 0.85);
-  background: rgba(248, 113, 113, 0.18);
-  color: rgba(153, 27, 27, 0.98);
-  box-shadow: 0 8px 16px rgba(248, 113, 113, 0.18);
 }
 
 .admin-prompts__empty {
-  padding: 1.2rem;
-  border-radius: 14px;
-  border: 1px dashed rgba(148, 163, 184, 0.6);
-  background: rgba(248, 250, 252, 0.7);
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--gray-600, #4b5563);
+}
+
+.admin-prompts__toggles {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.admin-prompts__model-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.admin-prompts__model-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   font-size: 0.9rem;
-  color: #475569;
+  color: var(--gray-700, #374151);
+}
+
+.admin-prompts__model-field input[type='number'] {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--gray-300, #d1d5db);
+}
+
+.admin-prompts__preview {
+  padding: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--surface, #fff);
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+  color: var(--gray-800, #1f2937);
+  overflow-x: auto;
 }
 
 .admin-prompts__status {
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  font-size: 0.92rem;
+  padding: 12px 16px;
+  border-radius: 10px;
   font-weight: 600;
 }
 
 .admin-prompts__status--success {
-  border: 1px solid rgba(34, 197, 94, 0.4);
-  background: rgba(187, 247, 208, 0.6);
-  color: #166534;
+  background-color: rgba(16, 185, 129, 0.12);
+  color: #047857;
 }
 
-.admin-prompts__status--info {
-  border: 1px solid rgba(96, 165, 250, 0.4);
-  background: rgba(191, 219, 254, 0.6);
-  color: #1d4ed8;
+.admin-prompts__status--error {
+  background-color: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
 }
 
 .admin-prompts__actions {
   display: flex;
+  gap: 12px;
   flex-wrap: wrap;
-  gap: 0.9rem;
-  justify-content: flex-end;
 }
 
 .admin-prompts__primary {
-  padding: 0.65rem 1.4rem;
-  border-radius: 999px;
+  padding: 10px 18px;
+  border-radius: 8px;
   border: none;
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-  color: white;
-  font-size: 0.95rem;
-  font-weight: 700;
+  background-color: var(--primary-600, #2563eb);
+  color: #fff;
+  font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.admin-prompts__primary:hover,
-.admin-prompts__primary:focus-visible {
+.admin-prompts__primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.admin-prompts__primary:hover:not(:disabled),
+.admin-prompts__primary:focus-visible:not(:disabled) {
+  background-color: var(--primary-700, #1d4ed8);
   outline: none;
-  transform: translateY(-1px);
-  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.4);
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 960px) {
   .admin-prompts__layout {
     grid-template-columns: 1fr;
   }
 
-  .admin-prompts__nav {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-  }
-
-  .admin-prompts__nav-button {
-    flex: 1 1 220px;
-  }
-}
-
-@media (max-width: 640px) {
-  .admin-prompts__grid {
-    grid-template-columns: 1fr;
-  }
-
-  .admin-prompts__list-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .admin-prompts__list-footer {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .admin-prompts__notes {
-    width: 100%;
+  .admin-prompts__content {
+    padding: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- add a prompt configuration service with persisted defaults, camelCase aliases, and built-in context metadata
- expose /admin/prompts APIs and update AI generation to assemble prompts from runtime settings with selective cleanup
- rebuild the admin prompts page to load/save via the backend, manage sections and contexts, and show preview output

## Testing
- pytest backend -q
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25c38412c833096dc9ee48e5c82f1