### PR TITLE
Fix image URL attachments to remain strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # tta-ai-project
 AI-ON 업무혁신 공모전
+
+## Attachment descriptor template placeholders
+The admin prompts page lets you customize how attachment descriptions are rendered using a template string. The following placeholder keys are supported in the template:
+
+- `{{index}}`: 1-based position of the attachment in the list that will be shown to the model.
+- `{{descriptor}}`: Human-readable title generated from the attachment metadata (label, filename, and file extension).
+- `{{label}}`: Friendly name entered for the attachment; falls back to the uploaded filename when no label is provided.
+- `{{description}}`: Longer free-text description supplied with the attachment metadata.
+- `{{extension}}`: File extension (for example, `pdf`, `pptx`, or `jpg`).
+- `{{doc_id}}`: Identifier of a required document when one is available; otherwise this placeholder resolves to an empty string.
+- `{{notes}}`: Any additional notes that were stored with the attachment.
+- `{{source_path}}`: Original source path stored in the attachment metadata.
+
+When you upload multiple files the admin preview also shows the `{{context_summary}}` placeholder. It expands to a comma-separated list of the attachment labels (falling back to each file's descriptor when no label is provided). For example, uploading three files labeled `User manual`, `설치 가이드`, and `테스트 결과` will produce the summary `User manual, 설치 가이드, 테스트 결과`.

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import io
+import json
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 from starlette.datastructures import Headers
+import httpx
 
 # Ensure the backend/app package is importable when running tests from the repository root.
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
@@ -17,6 +19,7 @@ if str(BACKEND_ROOT) not in sys.path:
 from app.config import Settings
 from app.services.ai_generation import AIGenerationService
 from app.services.openai_payload import OpenAIMessageBuilder
+from openai import BadRequestError, OpenAIError, RateLimitError
 
 
 class _StubFiles:
@@ -48,6 +51,26 @@ class _StubClient:
     def __init__(self) -> None:
         self.files = _StubFiles()
         self.responses = _StubResponses()
+
+
+def _build_rate_limit_error(message: str = "quota exceeded") -> RateLimitError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(
+        429,
+        request=request,
+        json={"error": {"message": message, "code": "insufficient_quota"}},
+    )
+    return RateLimitError(message=message, response=response, body=response.json())
+
+
+def _build_bad_request_error(message: str) -> BadRequestError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(
+        400,
+        request=request,
+        json={"error": {"message": message, "code": "invalid_prompt"}},
+    )
+    return BadRequestError(message=message, response=response, body=response.json())
 
 
 def _settings() -> Settings:
@@ -121,7 +144,15 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
 
     # The response payload should include input_file parts for each uploaded file.
     assert len(stub_client.responses.calls) == 1
-    messages = stub_client.responses.calls[0]["input"]
+    response_payload = stub_client.responses.calls[0]
+    # Ensure the payload we send to OpenAI is JSON serialisable, mirroring the
+    # client-side validation performed by the OpenAI SDK.
+    json.dumps(response_payload)
+
+    assert "presence_penalty" not in response_payload
+    assert "frequency_penalty" not in response_payload
+
+    messages = response_payload["input"]
     assert isinstance(messages, list)
     user_message = messages[1]
     file_parts = [
@@ -146,6 +177,45 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
 
     # Temporary files should be cleaned up after the request completes.
     assert stub_client.files.deleted == ["file-1"]
+
+    assert result.csv_text == "col1,col2\nvalue1,value2"
+
+
+@pytest.mark.anyio
+async def test_generate_csv_supports_modern_response_payload() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _modern_response(**kwargs: object) -> SimpleNamespace:
+        stub_client.responses.calls.append(kwargs)
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="output_text",
+                            text={"value": "col1,col2\nvalue1,value2", "annotations": []},
+                        )
+                    ]
+                )
+            ]
+        )
+
+    stub_client.responses.create = _modern_response  # type: ignore[assignment]
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    result = await service.generate_csv(
+        project_id="proj-modern",
+        menu_id="feature-list",
+        uploads=[upload],
+        metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+    )
 
     assert result.csv_text == "col1,col2\nvalue1,value2"
 
@@ -207,4 +277,157 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
         "type": "input_image",
         "image_url": "https://example.com/additional.png",
     } in image_parts
+
+
+@pytest.mark.anyio
+async def test_generate_csv_surfaces_openai_response_error() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _raise_response_error(**kwargs: object) -> None:
+        raise OpenAIError("temporary overload")
+
+    stub_client.responses.create = _raise_response_error  # type: ignore[assignment]
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.generate_csv(
+            project_id="proj-error",
+            menu_id="feature-list",
+            uploads=[upload],
+            metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "OpenAI 호출 중 오류가 발생했습니다" in excinfo.value.detail
+    assert "temporary overload" in excinfo.value.detail
+
+
+@pytest.mark.anyio
+async def test_generate_csv_surfaces_rate_limit_error() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _raise_rate_limit(**kwargs: object) -> None:
+        raise _build_rate_limit_error(
+            "You exceeded your current quota, please check your plan and billing details."
+        )
+
+    stub_client.responses.create = _raise_rate_limit  # type: ignore[assignment]
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.generate_csv(
+            project_id="proj-rate-limit",
+            menu_id="feature-list",
+            uploads=[upload],
+            metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+        )
+
+    assert excinfo.value.status_code == 429
+    assert "OpenAI 사용량 한도를 초과했습니다" in excinfo.value.detail
+    assert "You exceeded your current quota" in excinfo.value.detail
+
+
+@pytest.mark.anyio
+async def test_generate_csv_includes_message_for_unexpected_error() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _raise_type_error(**kwargs: object) -> None:
+        raise TypeError("Object of type bytes is not JSON serializable")
+
+    stub_client.responses.create = _raise_type_error  # type: ignore[assignment]
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.generate_csv(
+            project_id="proj-type-error",
+            menu_id="feature-list",
+            uploads=[upload],
+            metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "예기치 않은 오류" in excinfo.value.detail
+    assert "Object of type bytes is not JSON serializable" in excinfo.value.detail
+
+
+@pytest.mark.anyio
+async def test_generate_csv_surfaces_bad_request_error_detail() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _raise_bad_request(**kwargs: object) -> None:
+        raise _build_bad_request_error("Invalid prompt format")
+
+    stub_client.responses.create = _raise_bad_request  # type: ignore[assignment]
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.generate_csv(
+            project_id="proj-bad-request",
+            menu_id="feature-list",
+            uploads=[upload],
+            metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "Invalid prompt format" in excinfo.value.detail
+
+
+@pytest.mark.anyio
+async def test_generate_csv_surfaces_openai_file_upload_error() -> None:
+    service = AIGenerationService(_settings())
+    stub_client = _StubClient()
+    service._client = stub_client  # type: ignore[attr-defined]
+
+    def _raise_file_error(
+        self, *, file: tuple[str, io.BytesIO], purpose: str
+    ) -> SimpleNamespace:
+        raise OpenAIError("file quota reached")
+
+    stub_client.files.create = MethodType(_raise_file_error, stub_client.files)
+
+    upload = UploadFile(
+        file=io.BytesIO(b"Primary document"),
+        filename="요구사항.docx",
+        headers=Headers({"content-type": "application/msword"}),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await service.generate_csv(
+            project_id="proj-file-error",
+            menu_id="feature-list",
+            uploads=[upload],
+            metadata=[{"role": "required", "id": "doc-1", "label": "주요 문서"}],
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "OpenAI 파일 업로드 중 오류가 발생했습니다" in excinfo.value.detail
+    assert "file quota reached" in excinfo.value.detail
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -47,6 +47,24 @@ def test_text_message_appends_image_parts_from_data_url() -> None:
     ]
 
 
+def test_text_message_converts_mapping_image_urls() -> None:
+    data_url = "data:image/png;base64,xyz456"
+    message = OpenAIMessageBuilder.text_message(
+        "user",
+        "see mapping",
+        attachments=[{"image_url": {"url": data_url}, "kind": "image"}],
+    )
+
+    assert message["content"][1:] == [
+        {"type": "input_image", "image_url": data_url}
+    ]
+
+    normalized = OpenAIMessageBuilder.normalize_messages([message])
+    assert normalized[0]["content"][1:] == [
+        {"type": "input_image", "image_url": data_url}
+    ]
+
+
 def test_text_message_appends_image_parts_from_image_url() -> None:
     message = OpenAIMessageBuilder.text_message(
         "user",
@@ -107,7 +125,7 @@ def test_attachments_to_chat_completions_converts_images() -> None:
     assert completion_parts == [
         {
             "type": "input_image",
-            "image_url": {"url": "data:image/png;base64,xyz456"},
+            "image_url": "data:image/png;base64,xyz456",
         }
     ]
 
@@ -124,7 +142,7 @@ def test_attachments_to_chat_completions_prefers_image_url() -> None:
     completion_parts = OpenAIMessageBuilder.attachments_to_chat_completions(attachments)
 
     assert completion_parts == [
-        {"type": "input_image", "image_url": {"url": "data:image/png;base64,abc123"}}
+        {"type": "input_image", "image_url": "data:image/png;base64,abc123"}
     ]
 
 


### PR DESCRIPTION
## Summary
- ensure chat completion attachment conversion emits plain string image_url values instead of nested objects
- keep CSV generation flow tests aligned with string-only image_url normalization
- update payload unit tests to assert string-based image_url outputs

## Testing
- PYTHONPATH=backend pytest backend/tests/test_openai_payload.py -q
- PYTHONPATH=backend pytest backend/tests/test_ai_generation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e398f91a208330a4662b1e69432b4e