### PR TITLE
Normalize image_url content as string

### DIFF
--- a/backend/app/services/openai_payload.py
+++ b/backend/app/services/openai_payload.py
@@ -40,17 +40,11 @@ class InputImageFileContent(TypedDict):
     image: ImageFileReference
 
 
-class ImageURLReference(TypedDict):
-    """Response API image_url payload structure."""
-
-    url: str
-
-
 class InputImageURLContent(TypedDict):
     """Response API image content that references an external URL."""
 
     type: _ImageContentType
-    image_url: ImageURLReference
+    image_url: str
 
 
 class TextContent(TypedDict):
@@ -372,7 +366,7 @@ class OpenAIMessageBuilder:
             external_url = cls._normalize_external_image_url(
                 image_url, context=item
             )
-            return {"type": "input_image", "image_url": {"url": external_url}}
+            return {"type": "input_image", "image_url": external_url}
 
         cls._log_invalid_image_part(
             "input_image 항목에는 image_url이 필요합니다.",

--- a/backend/tests/test_ai_generation.py
+++ b/backend/tests/test_ai_generation.py
@@ -164,7 +164,7 @@ async def test_generate_csv_attaches_files_and_cleans_up() -> None:
         {"type": "input_file", "file_id": "file-1"},
         {
             "type": "input_image",
-            "image_url": {"url": "data:image/png;base64,SW1hZ2UgYnl0ZXM="},
+            "image_url": "data:image/png;base64,SW1hZ2UgYnl0ZXM=",
         },
         {"type": "input_file", "file_id": "file-2"},
     ]
@@ -271,11 +271,11 @@ async def test_generate_csv_normalizes_image_url_content(monkeypatch: pytest.Mon
     ]
     assert {
         "type": "input_image",
-        "image_url": {"url": "data:image/png;base64,abc123"},
+        "image_url": "data:image/png;base64,abc123",
     } in image_parts
     assert {
         "type": "input_image",
-        "image_url": {"url": "https://example.com/additional.png"},
+        "image_url": "https://example.com/additional.png",
     } in image_parts
 
 

--- a/backend/tests/test_openai_payload.py
+++ b/backend/tests/test_openai_payload.py
@@ -38,12 +38,12 @@ def test_text_message_appends_image_parts_from_data_url() -> None:
 
     assert message["role"] == "user"
     assert message["content"][1:] == [
-        {"type": "input_image", "image_url": {"url": data_url}}
+        {"type": "input_image", "image_url": data_url}
     ]
 
     normalized = OpenAIMessageBuilder.normalize_messages([message])
     assert normalized[0]["content"][1:] == [
-        {"type": "input_image", "image_url": {"url": data_url}}
+        {"type": "input_image", "image_url": data_url}
     ]
 
 
@@ -98,7 +98,7 @@ def test_text_message_appends_image_parts_from_image_url() -> None:
     assert message["content"][1:] == [
         {
             "type": "input_image",
-            "image_url": {"url": "https://example.com/external.png"},
+            "image_url": "https://example.com/external.png",
         }
     ]
 
@@ -106,7 +106,7 @@ def test_text_message_appends_image_parts_from_image_url() -> None:
     assert normalized[0]["content"][1:] == [
         {
             "type": "input_image",
-            "image_url": {"url": "https://example.com/external.png"},
+            "image_url": "https://example.com/external.png",
         }
     ]
 
@@ -121,7 +121,7 @@ def test_text_message_accepts_image_url_alias() -> None:
     assert message["content"][1:] == [
         {
             "type": "input_image",
-            "image_url": {"url": "https://example.com/from-alias"},
+            "image_url": "https://example.com/from-alias",
         }
     ]
 
@@ -263,7 +263,7 @@ def test_normalize_messages_preserves_external_image_url() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": {"url": "https://example.com/image.png"},
+                    "image_url": "https://example.com/image.png",
                 },
             ],
         }
@@ -292,7 +292,7 @@ def test_normalize_messages_preserves_data_image_url() -> None:
             "content": [
                 {
                     "type": "input_image",
-                    "image_url": {"url": data_url},
+                    "image_url": data_url,
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- update OpenAI payload typing so image parts carry image_url values as strings instead of nested url objects
- adjust image normalization to emit string image_url values and keep compatibility when normalizing content
- refresh unit tests to assert the new string-based image_url payloads

## Testing
- pytest backend/tests/test_openai_payload.py
- pytest backend/tests/test_ai_generation.py::test_generate_csv_normalizes_image_url_content

------
https://chatgpt.com/codex/tasks/task_e_68e4846a3a4c833081f9d91c9cb41263