### PR TITLE
Log generated prompts and surface in admin page

### DIFF
--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .config import Settings, load_settings
 from .services.ai_generation import AIGenerationService
 from .services.prompt_config import PromptConfigService
+from .services.prompt_request_log import PromptRequestLogService
 from .services.google_drive import GoogleDriveService
 from .services.oauth import GoogleOAuthService
 from .token_store import TokenStorage
@@ -20,8 +21,10 @@ class Container:
         )
         prompt_storage_path = self._settings.tokens_path.with_name("prompt_configs.json")
         self._prompt_config_service = PromptConfigService(prompt_storage_path)
+        request_log_path = self._settings.tokens_path.with_name("prompt_requests.log")
+        self._prompt_request_log_service = PromptRequestLogService(request_log_path)
         self._ai_generation_service = AIGenerationService(
-            self._settings, self._prompt_config_service
+            self._settings, self._prompt_config_service, self._prompt_request_log_service
         )
 
     @property
@@ -47,3 +50,7 @@ class Container:
     @property
     def prompt_config_service(self) -> PromptConfigService:
         return self._prompt_config_service
+
+    @property
+    def prompt_request_log_service(self) -> PromptRequestLogService:
+        return self._prompt_request_log_service

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -6,6 +6,7 @@ from .container import Container
 from .services.ai_generation import AIGenerationService
 from .services.google_drive import GoogleDriveService
 from .services.prompt_config import PromptConfigService
+from .services.prompt_request_log import PromptRequestLogService
 from .services.oauth import GoogleOAuthService
 from .token_store import TokenStorage
 
@@ -39,3 +40,9 @@ def get_prompt_config_service(
     container: Container = Depends(get_container),
 ) -> PromptConfigService:
     return container.prompt_config_service
+
+
+def get_prompt_request_log_service(
+    container: Container = Depends(get_container),
+) -> PromptRequestLogService:
+    return container.prompt_request_log_service

--- a/backend/app/routes/prompts.py
+++ b/backend/app/routes/prompts.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from typing import Dict
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ..dependencies import get_prompt_config_service
+from ..dependencies import (
+    get_prompt_config_service,
+    get_prompt_request_log_service,
+)
 from ..services.prompt_config import PromptConfig, PromptConfigService
+from ..services.prompt_request_log import PromptRequestLogService
 
 router = APIRouter(prefix="/admin/prompts", tags=["prompt-config"])
 
@@ -50,3 +54,12 @@ def update_prompt_config(
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="알 수 없는 메뉴입니다.") from exc
     return {"config": updated.model_dump(mode="json", by_alias=True)}
+
+
+@router.get("/logs")
+def list_prompt_request_logs(
+    limit: int = Query(50, ge=1, le=200, description="가져올 로그 수"),
+    log_service: PromptRequestLogService = Depends(get_prompt_request_log_service),
+) -> Dict[str, list[dict[str, str]]]:
+    entries = log_service.list_recent(limit=limit)
+    return {"logs": [entry.to_dict() for entry in entries]}

--- a/backend/app/services/prompt_request_log.py
+++ b/backend/app/services/prompt_request_log.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import List
+
+
+@dataclass(frozen=True)
+class PromptRequestLogEntry:
+    """Recorded information about a generated prompt request."""
+
+    request_id: str
+    timestamp: str
+    project_id: str
+    menu_id: str
+    system_prompt: str
+    user_prompt: str
+    context_summary: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(payload: dict[str, object]) -> PromptRequestLogEntry | None:
+        try:
+            request_id = str(payload["request_id"])
+            timestamp = str(payload["timestamp"])
+            project_id = str(payload["project_id"])
+            menu_id = str(payload["menu_id"])
+            system_prompt = str(payload.get("system_prompt", ""))
+            user_prompt = str(payload.get("user_prompt", ""))
+            context_summary = str(payload.get("context_summary", ""))
+        except (KeyError, TypeError, ValueError):
+            return None
+
+        return PromptRequestLogEntry(
+            request_id=request_id,
+            timestamp=timestamp,
+            project_id=project_id,
+            menu_id=menu_id,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            context_summary=context_summary,
+        )
+
+
+class PromptRequestLogService:
+    """Persist and retrieve prompt request log entries."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self._storage_path = storage_path
+        self._lock = Lock()
+        storage_path.parent.mkdir(parents=True, exist_ok=True)
+        storage_path.touch(exist_ok=True)
+
+    def record_request(
+        self,
+        *,
+        project_id: str,
+        menu_id: str,
+        system_prompt: str,
+        user_prompt: str,
+        context_summary: str | None = None,
+    ) -> PromptRequestLogEntry:
+        entry = PromptRequestLogEntry(
+            request_id=uuid.uuid4().hex,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            project_id=project_id,
+            menu_id=menu_id,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            context_summary=context_summary or "",
+        )
+        payload = json.dumps(entry.to_dict(), ensure_ascii=False)
+        with self._lock:
+            with self._storage_path.open("a", encoding="utf-8") as file:
+                file.write(payload + "\n")
+        return entry
+
+    def list_recent(self, limit: int = 50) -> List[PromptRequestLogEntry]:
+        if limit <= 0:
+            return []
+
+        with self._lock:
+            try:
+                lines = self._storage_path.read_text(encoding="utf-8").splitlines()
+            except FileNotFoundError:
+                return []
+
+        entries: List[PromptRequestLogEntry] = []
+        for raw in lines[-limit:]:
+            if not raw.strip():
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            entry = PromptRequestLogEntry.from_dict(payload if isinstance(payload, dict) else {})
+            if entry is not None:
+                entries.append(entry)
+
+        entries.reverse()
+        return entries
+
+    def purge(self) -> None:
+        """Delete all recorded entries."""
+
+        with self._lock:
+            self._storage_path.write_text("", encoding="utf-8")

--- a/backend/tests/test_prompt_request_log_service.py
+++ b/backend/tests/test_prompt_request_log_service.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.prompt_request_log import (
+    PromptRequestLogEntry,
+    PromptRequestLogService,
+)
+
+
+def test_record_and_list_recent(tmp_path: Path) -> None:
+    log_path = tmp_path / "prompt_requests.log"
+    service = PromptRequestLogService(log_path)
+
+    service.record_request(
+        project_id="project-1",
+        menu_id="feature-list",
+        system_prompt="system",
+        user_prompt="user",
+        context_summary="summary",
+    )
+    second = service.record_request(
+        project_id="project-2",
+        menu_id="defect-report",
+        system_prompt="system-2",
+        user_prompt="user-2",
+        context_summary="",
+    )
+
+    entries = service.list_recent()
+    assert len(entries) == 2
+    assert entries[0].request_id == second.request_id
+    assert entries[0].context_summary == ""
+    assert entries[1].project_id == "project-1"
+
+
+def test_list_recent_ignores_invalid_rows(tmp_path: Path) -> None:
+    log_path = tmp_path / "prompt_requests.log"
+    log_path.write_text("not json\n{}\n", encoding="utf-8")
+
+    service = PromptRequestLogService(log_path)
+    service.record_request(
+        project_id="project",
+        menu_id="feature-list",
+        system_prompt="system",
+        user_prompt="user",
+    )
+
+    entries = service.list_recent(limit=5)
+    assert len(entries) == 1
+    assert isinstance(entries[0], PromptRequestLogEntry)

--- a/frontend/src/pages/AdminPromptsPage.css
+++ b/frontend/src/pages/AdminPromptsPage.css
@@ -184,6 +184,108 @@
   background-color: var(--gray-50, #f9fafb);
 }
 
+.admin-prompts__logs {
+  background-color: var(--surface, #fff);
+}
+
+.admin-prompts__logs-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--gray-600, #4b5563);
+  line-height: 1.5;
+}
+
+.admin-prompts__log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-prompts__log-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--gray-50, #f9fafb);
+}
+
+.admin-prompts__log-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-prompts__log-menu {
+  font-weight: 600;
+  color: var(--gray-800, #1f2937);
+}
+
+.admin-prompts__log-time {
+  font-size: 0.8rem;
+  color: var(--gray-500, #6b7280);
+}
+
+.admin-prompts__log-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--gray-600, #4b5563);
+  line-height: 1.5;
+}
+
+.admin-prompts__log-project {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--gray-500, #6b7280);
+  word-break: break-word;
+}
+
+.admin-prompts__log-details {
+  border-radius: 8px;
+  background-color: var(--surface, #fff);
+  border: 1px solid var(--gray-200, #e5e7eb);
+  padding: 10px 12px;
+}
+
+.admin-prompts__log-details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--primary-600, #2563eb);
+  outline: none;
+}
+
+.admin-prompts__log-details-content {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-prompts__log-heading {
+  margin: 0 0 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gray-700, #374151);
+}
+
+.admin-prompts__log-block {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--gray-800, #1f2937);
+  background-color: var(--gray-50, #f9fafb);
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
 .admin-prompts__group-header {
   display: flex;
   align-items: center;
@@ -213,6 +315,12 @@
 .admin-prompts__secondary:focus-visible {
   background-color: rgba(37, 99, 235, 0.08);
   outline: none;
+}
+
+.admin-prompts__secondary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background-color: transparent;
 }
 
 .admin-prompts__list {
@@ -275,6 +383,10 @@
   margin: 0;
   font-size: 0.95rem;
   color: var(--gray-600, #4b5563);
+}
+
+.admin-prompts__empty--error {
+  color: var(--rose-600, #e11d48);
 }
 
 .admin-prompts__toggles {


### PR DESCRIPTION
## Summary
- persist generated prompt requests via a new log service and expose them through the admin prompts API
- record OpenAI prompt payloads during CSV generation and surface recent requests with project context in the admin UI
- style and test the new log retrieval to ensure resilience against malformed entries

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e49c412c4883309bdf3d00f88889b3