### PR TITLE
feat: improve admin prompts layout and navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -165,6 +165,10 @@
   gap: 2.5rem;
 }
 
+.page.page--wide {
+  width: min(1280px, 100%);
+}
+
 .page__header {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { AppShell } from './app/components/AppShell'
 import { useAuthStatus } from './app/hooks/useAuthStatus'
@@ -9,6 +9,7 @@ import { useRouteGuards } from './app/routing/useRouteGuards'
 import { clearAuthentication } from './auth'
 import { openGoogleDriveWorkspace } from './drive'
 import { navigate } from './navigation'
+import { LAST_PROJECT_PATH_STORAGE_KEY } from './pages/adminPromptsStorage'
 
 function App() {
   const authStatus = useAuthStatus()
@@ -17,6 +18,20 @@ function App() {
   useRouteGuards(pathname, authStatus)
 
   const pageContent = useMemo(() => resolvePage({ pathname, authStatus }), [pathname, authStatus])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (pathname.startsWith('/projects')) {
+      try {
+        window.sessionStorage.setItem(LAST_PROJECT_PATH_STORAGE_KEY, pathname)
+      } catch (storageError) {
+        console.error('프로젝트 경로를 저장하지 못했습니다.', storageError)
+      }
+    }
+  }, [pathname])
 
   const handleLogout = useCallback(() => {
     clearAuthentication()

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -1,5 +1,12 @@
 import type { PropsWithChildren } from 'react'
 
-export function PageLayout({ children }: PropsWithChildren) {
-  return <div className="page">{children}</div>
+interface PageLayoutProps {
+  variant?: 'default' | 'wide'
+  className?: string
+}
+
+export function PageLayout({ children, variant = 'default', className }: PropsWithChildren<PageLayoutProps>) {
+  const classes = ['page', variant === 'wide' ? 'page--wide' : '', className].filter(Boolean).join(' ')
+
+  return <div className={classes}>{children}</div>
 }

--- a/frontend/src/pages/AdminPromptsPage.css
+++ b/frontend/src/pages/AdminPromptsPage.css
@@ -1,7 +1,7 @@
 .admin-prompts {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 32px;
   padding: 16px 0 48px;
 }
 
@@ -25,9 +25,74 @@
   background-color: var(--rose-50, #fff1f2);
 }
 
+.admin-prompts__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 18px 24px;
+  border-radius: 16px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--surface, #fff);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
+}
+
+.admin-prompts__back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0.24));
+  color: var(--primary-700, #1d4ed8);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.admin-prompts__back-button:hover,
+.admin-prompts__back-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+  outline: none;
+}
+
+.admin-prompts__back-button span:first-child {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.admin-prompts__toolbar-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-prompts__toolbar-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background-color: var(--gray-100, #f3f4f6);
+  color: var(--gray-700, #374151);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .admin-prompts__layout {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 32px;
+  align-items: start;
+}
+
+.admin-prompts__workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.9fr);
   gap: 28px;
   align-items: start;
 }
@@ -105,10 +170,9 @@
 }
 
 .admin-prompts__content-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
-  gap: 32px;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .admin-prompts__main {
@@ -117,12 +181,182 @@
   gap: 24px;
 }
 
-.admin-prompts__sidebar {
+.admin-prompts__meta {
   display: flex;
   flex-direction: column;
   gap: 24px;
   position: sticky;
   top: 96px;
+}
+
+.admin-prompts__card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 22px;
+  border-radius: 14px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--surface, #fff);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.admin-prompts__card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-prompts__card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--gray-900, #111827);
+}
+
+.admin-prompts__card-subtitle {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: var(--gray-600, #4b5563);
+  line-height: 1.5;
+}
+
+.admin-prompts__card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-prompts__tertiary {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--gray-300, #d1d5db);
+  background-color: transparent;
+  color: var(--gray-700, #374151);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.admin-prompts__tertiary:hover,
+.admin-prompts__tertiary:focus-visible {
+  background-color: rgba(37, 99, 235, 0.08);
+  border-color: var(--primary-400, #60a5fa);
+  color: var(--primary-600, #2563eb);
+  outline: none;
+}
+
+.admin-prompts__preview {
+  border-radius: 12px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--gray-50, #f9fafb);
+  padding: 16px;
+  max-height: 320px;
+  overflow: auto;
+  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--gray-800, #1f2937);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.admin-prompts__preview pre {
+  margin: 0;
+}
+
+.admin-prompts__preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--gray-500, #6b7280);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.admin-prompts__preview--empty p {
+  margin: 0;
+}
+
+.admin-prompts__feedback {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.admin-prompts__feedback--success {
+  color: #047857;
+}
+
+.admin-prompts__feedback--error {
+  color: #b91c1c;
+}
+
+.admin-prompts__history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-prompts__history-item {
+  display: block;
+}
+
+.admin-prompts__history-button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 12px;
+  background-color: var(--surface, #fff);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.admin-prompts__history-button:hover,
+.admin-prompts__history-button:focus-visible {
+  border-color: var(--primary-400, #60a5fa);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
+  outline: none;
+}
+
+.admin-prompts__history-button--active {
+  border-color: var(--primary-500, #3b82f6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
+.admin-prompts__history-label {
+  font-weight: 600;
+  color: var(--gray-900, #111827);
+}
+
+.admin-prompts__history-summary {
+  font-size: 0.85rem;
+  color: var(--gray-600, #4b5563);
+  line-height: 1.4;
+}
+
+.admin-prompts__history-time {
+  font-size: 0.8rem;
+  color: var(--gray-500, #6b7280);
+}
+
+.admin-prompts__history-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--gray-600, #4b5563);
+}
+
+.admin-prompts__card--hint {
+  border-color: var(--primary-200, #bfdbfe);
+  background: linear-gradient(180deg, rgba(219, 234, 254, 0.45) 0%, rgba(219, 234, 254, 0.2) 100%);
+  color: var(--primary-800, #1e3a8a);
 }
 
 .admin-prompts__field {
@@ -303,17 +537,6 @@
   border: 1px solid var(--gray-300, #d1d5db);
 }
 
-.admin-prompts__hint {
-  border-radius: 12px;
-  border: 1px solid var(--primary-100, #dbeafe);
-  background: linear-gradient(180deg, rgba(219, 234, 254, 0.45) 0%, rgba(219, 234, 254, 0.15) 100%);
-  padding: 18px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  color: var(--primary-800, #1e3a8a);
-}
-
 .admin-prompts__hint-title {
   margin: 0;
   font-size: 0.95rem;
@@ -346,6 +569,8 @@
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
 }
 
 .admin-prompts__primary {
@@ -369,31 +594,50 @@
   outline: none;
 }
 
-@media (max-width: 1200px) {
-  .admin-prompts__content-body {
-    grid-template-columns: 1fr;
-  }
-
-  .admin-prompts__sidebar {
-    position: static;
-  }
-
+@media (max-width: 1280px) {
   .admin-prompts__layout {
-    grid-template-columns: 220px minmax(0, 1fr);
-    gap: 20px;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 24px;
+  }
+
+  .admin-prompts__workspace {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .admin-prompts__meta {
+    position: static;
   }
 }
 
 @media (max-width: 960px) {
   .admin-prompts__layout {
     grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .admin-prompts__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-prompts__nav {
+    position: static;
+    flex-direction: row;
+    gap: 12px;
+    overflow-x: auto;
+    padding-bottom: 8px;
+  }
+
+  .admin-prompts__nav-item {
+    min-width: 220px;
   }
 
   .admin-prompts__content {
     padding: 20px;
   }
 
-  .admin-prompts__nav {
+  .admin-prompts__meta {
     position: static;
   }
 }

--- a/frontend/src/pages/AdminPromptsPage.tsx
+++ b/frontend/src/pages/AdminPromptsPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { getBackendUrl } from '../config'
 import { PageHeader } from '../components/layout/PageHeader'
 import { PageLayout } from '../components/layout/PageLayout'
 import { Modal } from '../components/Modal'
+import { navigate } from '../navigation'
+import { LAST_PROJECT_PATH_STORAGE_KEY, RECENT_PROMPT_STORAGE_KEY } from './adminPromptsStorage'
 
 import './AdminPromptsPage.css'
 
@@ -67,6 +69,13 @@ type PromptResponsePayload = {
   defaults: Record<string, PromptConfig>
 }
 
+type RecentPromptEntry = {
+  id: PromptCategory
+  label: string
+  summary: string
+  visitedAt: number
+}
+
 function isPromptCategory(value: string): value is PromptCategory {
   return (
     value === 'feature-list' ||
@@ -95,6 +104,28 @@ function cloneConfigMap(raw: Record<string, PromptConfig>): PromptConfigResponse
 }
 
 const PREVIEW_CONTEXT_SUMMARY = '사용자 매뉴얼 등 업로드 자료'
+const RECENT_VISIT_LIMIT = 5
+
+function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+
+  if (diff < minute) {
+    return '방금 전'
+  }
+  if (diff < hour) {
+    const minutes = Math.floor(diff / minute)
+    return `${minutes}분 전`
+  }
+  if (diff < day) {
+    const hours = Math.floor(diff / hour)
+    return `${hours}시간 전`
+  }
+  const days = Math.floor(diff / day)
+  return `${days}일 전`
+}
 
 function buildPreview(config: PromptConfig): string {
   const parts: string[] = []
@@ -171,6 +202,10 @@ export function AdminPromptsPage() {
   const [saving, setSaving] = useState(false)
   const [status, setStatus] = useState<{ type: StatusType; message: string }>({ type: 'idle', message: '' })
   const [previewOpen, setPreviewOpen] = useState(false)
+  const [recentEntries, setRecentEntries] = useState<RecentPromptEntry[]>([])
+  const [returnPath, setReturnPath] = useState('/projects')
+  const [copyState, setCopyState] = useState<StatusType>('idle')
+  const [copyMessage, setCopyMessage] = useState('')
 
   useEffect(() => {
     const controller = new AbortController()
@@ -206,8 +241,130 @@ export function AdminPromptsPage() {
     return () => controller.abort()
   }, [backendUrl])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    try {
+      const storedPath = window.sessionStorage.getItem(LAST_PROJECT_PATH_STORAGE_KEY)
+      if (storedPath && !storedPath.startsWith('/admin')) {
+        setReturnPath(storedPath)
+      }
+    } catch (storageError) {
+      console.error('프로젝트 경로를 불러오지 못했습니다.', storageError)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    try {
+      const raw = window.localStorage.getItem(RECENT_PROMPT_STORAGE_KEY)
+      if (!raw) {
+        return
+      }
+      const parsed = JSON.parse(raw) as RecentPromptEntry[]
+      if (!Array.isArray(parsed)) {
+        return
+      }
+      const sanitized = parsed.filter(
+        (entry): entry is RecentPromptEntry =>
+          Boolean(entry) && isPromptCategory(entry.id) && typeof entry.visitedAt === 'number',
+      )
+      if (sanitized.length > 0) {
+        setRecentEntries(sanitized.slice(0, RECENT_VISIT_LIMIT))
+      }
+    } catch (storageError) {
+      console.error('최근 편집 기록을 불러오지 못했습니다.', storageError)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!configs) {
+      return
+    }
+    const entryConfig = configs[activeCategory]
+    if (!entryConfig) {
+      return
+    }
+    if (typeof window === 'undefined') {
+      return
+    }
+    const entry: RecentPromptEntry = {
+      id: activeCategory,
+      label: entryConfig.label,
+      summary: entryConfig.summary,
+      visitedAt: Date.now(),
+    }
+    setRecentEntries((prev) => {
+      const filtered = prev.filter((item) => item.id !== entry.id)
+      const next = [entry, ...filtered].slice(0, RECENT_VISIT_LIMIT)
+      try {
+        window.localStorage.setItem(RECENT_PROMPT_STORAGE_KEY, JSON.stringify(next))
+      } catch (storageError) {
+        console.error('최근 편집 기록을 저장하지 못했습니다.', storageError)
+      }
+      return next
+    })
+  }, [activeCategory, configs])
+
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return
+    }
+    if (typeof window === 'undefined') {
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setCopyState('idle')
+      setCopyMessage('')
+    }, 2000)
+    return () => window.clearTimeout(timer)
+  }, [copyState])
+
   const activeConfig = configs ? configs[activeCategory] : null
   const preview = activeConfig ? buildPreview(activeConfig) : ''
+
+  const handleSelectCategory = useCallback(
+    (category: PromptCategory) => {
+      setActiveCategory(category)
+      setStatus({ type: 'idle', message: '' })
+      setCopyState('idle')
+      setCopyMessage('')
+    },
+    [],
+  )
+
+  const handleNavigateBack = useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      window.history.back()
+      return
+    }
+    navigate(returnPath || '/projects')
+  }, [returnPath])
+
+  const handleCopyPreview = useCallback(async () => {
+    if (!preview) {
+      return
+    }
+
+    if (typeof window === 'undefined' || !window.navigator?.clipboard) {
+      setCopyState('error')
+      setCopyMessage('복사를 지원하지 않는 환경입니다.')
+      return
+    }
+
+    try {
+      await window.navigator.clipboard.writeText(preview)
+      setCopyState('success')
+      setCopyMessage('미리보기를 복사했습니다.')
+    } catch (copyError) {
+      console.error(copyError)
+      setCopyState('error')
+      setCopyMessage('복사에 실패했습니다. 다시 시도해 주세요.')
+    }
+  }, [preview])
 
   const navItems = useMemo(() => {
     if (!configs) {
@@ -509,7 +666,7 @@ export function AdminPromptsPage() {
 
   if (loading) {
     return (
-      <PageLayout>
+      <PageLayout variant="wide">
         <div className="admin-prompts admin-prompts--loading">
           <PageHeader
             eyebrow="프롬프트 자산 관리"
@@ -524,7 +681,7 @@ export function AdminPromptsPage() {
 
   if (error || !configs || !activeConfig) {
     return (
-      <PageLayout>
+      <PageLayout variant="wide">
         <div className="admin-prompts admin-prompts--error">
           <PageHeader
             eyebrow="프롬프트 자산 관리"
@@ -538,13 +695,24 @@ export function AdminPromptsPage() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout variant="wide">
       <div className="admin-prompts">
         <PageHeader
           eyebrow="프롬프트 자산 관리"
           title="요청 템플릿 & 첨부 자료 설정"
           subtitle="생성 작업에 사용되는 시스템/사용자 프롬프트와 부가 정보를 실시간으로 조정하세요."
         />
+
+        <div className="admin-prompts__toolbar" role="navigation" aria-label="페이지 이동">
+          <button type="button" className="admin-prompts__back-button" onClick={handleNavigateBack}>
+            <span aria-hidden="true">←</span>
+            <span>프로젝트 페이지로 돌아가기</span>
+          </button>
+          <div className="admin-prompts__toolbar-meta" aria-live="polite">
+            <span className="admin-prompts__toolbar-chip">현재 카테고리: {activeConfig.label}</span>
+            <span className="admin-prompts__toolbar-chip">관리 중인 템플릿 {navItems.length}개</span>
+          </div>
+        </div>
 
         <div className="admin-prompts__layout">
           <nav className="admin-prompts__nav" aria-label="프롬프트 카테고리">
@@ -555,10 +723,7 @@ export function AdminPromptsPage() {
                   key={item.id}
                   type="button"
                   className={`admin-prompts__nav-item${isActive ? ' admin-prompts__nav-item--active' : ''}`}
-                  onClick={() => {
-                    setActiveCategory(item.id)
-                    setStatus({ type: 'idle', message: '' })
-                  }}
+                  onClick={() => handleSelectCategory(item.id)}
                 >
                   <span className="admin-prompts__nav-label">{item.label}</span>
                   <span className="admin-prompts__nav-summary">{item.summary || '설명 없음'}</span>
@@ -567,337 +732,398 @@ export function AdminPromptsPage() {
             })}
           </nav>
 
-          <section className="admin-prompts__content" aria-live="polite">
-            <header className="admin-prompts__content-header">
-              <h2 className="admin-prompts__title">{activeConfig.label}</h2>
-              <p className="admin-prompts__summary">{activeConfig.summary || '설명이 비어 있습니다.'}</p>
-            </header>
+          <div className="admin-prompts__workspace">
+            <section className="admin-prompts__content" aria-live="polite">
+              <header className="admin-prompts__content-header">
+                <h2 className="admin-prompts__title">{activeConfig.label}</h2>
+                <p className="admin-prompts__summary">{activeConfig.summary || '설명이 비어 있습니다.'}</p>
+              </header>
 
-            <div className="admin-prompts__content-body">
-              <div className="admin-prompts__main">
-                <div className="admin-prompts__field">
-                  <label className="admin-prompts__label" htmlFor="systemPrompt">시스템 프롬프트</label>
-                  <textarea
-                    id="systemPrompt"
-                    className="admin-prompts__textarea"
-                    value={activeConfig.systemPrompt}
-                    onChange={(event) => handleUpdateConfigField('systemPrompt', event.target.value)}
-                  />
-                </div>
+              <div className="admin-prompts__content-body">
+                <div className="admin-prompts__main">
+                  <div className="admin-prompts__field">
+                    <label className="admin-prompts__label" htmlFor="systemPrompt">시스템 프롬프트</label>
+                    <textarea
+                      id="systemPrompt"
+                      className="admin-prompts__textarea"
+                      value={activeConfig.systemPrompt}
+                      onChange={(event) => handleUpdateConfigField('systemPrompt', event.target.value)}
+                    />
+                  </div>
 
-                <div className="admin-prompts__field">
-                  <label className="admin-prompts__label" htmlFor="userPrompt">기본 사용자 지시</label>
-                  <textarea
-                    id="userPrompt"
-                    className="admin-prompts__textarea"
-                    value={activeConfig.userPrompt}
-                    onChange={(event) => handleUpdateConfigField('userPrompt', event.target.value)}
-                  />
-                </div>
+                  <div className="admin-prompts__field">
+                    <label className="admin-prompts__label" htmlFor="userPrompt">기본 사용자 지시</label>
+                    <textarea
+                      id="userPrompt"
+                      className="admin-prompts__textarea"
+                      value={activeConfig.userPrompt}
+                      onChange={(event) => handleUpdateConfigField('userPrompt', event.target.value)}
+                    />
+                  </div>
 
-                <section className="admin-prompts__group">
-                  <header className="admin-prompts__group-header">
-                    <h3 className="admin-prompts__group-title">추가 지침 블록</h3>
-                    <button type="button" className="admin-prompts__secondary" onClick={handleAddSection}>
-                      + 지침 추가
-                    </button>
-                  </header>
-                  {activeConfig.userPromptSections.length === 0 ? (
-                    <p className="admin-prompts__empty">등록된 지침이 없습니다. 필요한 내용을 추가하세요.</p>
-                  ) : (
-                    <ul className="admin-prompts__list">
-                      {activeConfig.userPromptSections.map((section) => (
-                        <li key={section.id} className="admin-prompts__list-item">
-                          <div className="admin-prompts__list-row">
-                            <div className="admin-prompts__field admin-prompts__field--half">
-                              <label className="admin-prompts__label" htmlFor={`${section.id}-label`}>
-                                제목
+                  <section className="admin-prompts__group">
+                    <header className="admin-prompts__group-header">
+                      <h3 className="admin-prompts__group-title">추가 지침 블록</h3>
+                      <button type="button" className="admin-prompts__secondary" onClick={handleAddSection}>
+                        + 지침 추가
+                      </button>
+                    </header>
+                    {activeConfig.userPromptSections.length === 0 ? (
+                      <p className="admin-prompts__empty">등록된 지침이 없습니다. 필요한 내용을 추가하세요.</p>
+                    ) : (
+                      <ul className="admin-prompts__list">
+                        {activeConfig.userPromptSections.map((section) => (
+                          <li key={section.id} className="admin-prompts__list-item">
+                            <div className="admin-prompts__list-row">
+                              <div className="admin-prompts__field admin-prompts__field--half">
+                                <label className="admin-prompts__label" htmlFor={`${section.id}-label`}>
+                                  제목
+                                </label>
+                                <input
+                                  id={`${section.id}-label`}
+                                  className="admin-prompts__input"
+                                  value={section.label}
+                                  onChange={(event) => handleUpdateSection(section.id, 'label', event.target.value)}
+                                />
+                              </div>
+                              <label className="admin-prompts__switch">
+                                <input
+                                  type="checkbox"
+                                  checked={section.enabled}
+                                  onChange={(event) => handleUpdateSection(section.id, 'enabled', event.target.checked)}
+                                />
+                                <span>활성화</span>
                               </label>
-                              <input
-                                id={`${section.id}-label`}
-                                className="admin-prompts__input"
-                                value={section.label}
-                                onChange={(event) => handleUpdateSection(section.id, 'label', event.target.value)}
+                            </div>
+                            <div className="admin-prompts__field">
+                              <label className="admin-prompts__label" htmlFor={`${section.id}-content`}>
+                                내용
+                              </label>
+                              <textarea
+                                id={`${section.id}-content`}
+                                className="admin-prompts__textarea"
+                                value={section.content}
+                                onChange={(event) => handleUpdateSection(section.id, 'content', event.target.value)}
                               />
                             </div>
-                            <label className="admin-prompts__switch">
-                              <input
-                                type="checkbox"
-                                checked={section.enabled}
-                                onChange={(event) => handleUpdateSection(section.id, 'enabled', event.target.checked)}
-                              />
-                              <span>활성화</span>
-                            </label>
-                          </div>
-                          <div className="admin-prompts__field">
-                            <label className="admin-prompts__label" htmlFor={`${section.id}-content`}>
-                              내용
-                            </label>
-                            <textarea
-                              id={`${section.id}-content`}
-                              className="admin-prompts__textarea"
-                              value={section.content}
-                              onChange={(event) => handleUpdateSection(section.id, 'content', event.target.value)}
-                            />
-                          </div>
-                          <button
-                            type="button"
-                            className="admin-prompts__remove"
-                            onClick={() => handleRemoveSection(section.id)}
-                            aria-label="지침 삭제"
-                          >
-                            삭제
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
-
-                <section className="admin-prompts__group">
-                  <h3 className="admin-prompts__group-title">첨부 안내 문구</h3>
-                  <div className="admin-prompts__field-grid">
-                    <div className="admin-prompts__field">
-                      <label className="admin-prompts__label" htmlFor="attachmentsHeading">섹션 제목</label>
-                      <input
-                        id="attachmentsHeading"
-                        className="admin-prompts__input"
-                        value={activeConfig.scaffolding.attachmentsHeading}
-                        onChange={(event) => handleScaffoldingChange('attachmentsHeading', event.target.value)}
-                      />
-                    </div>
-                    <div className="admin-prompts__field">
-                      <label className="admin-prompts__label" htmlFor="attachmentsIntro">소개 문구</label>
-                      <textarea
-                        id="attachmentsIntro"
-                        className="admin-prompts__textarea"
-                        value={activeConfig.scaffolding.attachmentsIntro}
-                        onChange={(event) => handleScaffoldingChange('attachmentsIntro', event.target.value)}
-                      />
-                    </div>
-                  </div>
-                  <div className="admin-prompts__field-grid">
-                    <div className="admin-prompts__field">
-                      <label className="admin-prompts__label" htmlFor="closingNote">
-                        마무리 문장 ({'{'}context_summary{'}'} 사용 가능)
-                      </label>
-                      <textarea
-                        id="closingNote"
-                        className="admin-prompts__textarea"
-                        value={activeConfig.scaffolding.closingNote}
-                        onChange={(event) => handleScaffoldingChange('closingNote', event.target.value)}
-                      />
-                    </div>
-                    <div className="admin-prompts__field">
-                      <label className="admin-prompts__label" htmlFor="formatWarning">형식 경고</label>
-                      <textarea
-                        id="formatWarning"
-                        className="admin-prompts__textarea"
-                        value={activeConfig.scaffolding.formatWarning}
-                        onChange={(event) => handleScaffoldingChange('formatWarning', event.target.value)}
-                      />
-                    </div>
-                  </div>
-                </section>
-
-                <div className="admin-prompts__field">
-                  <label className="admin-prompts__label" htmlFor="descriptorTemplate">
-                    첨부 설명 템플릿 (사용 가능 키: index, descriptor, label, description, extension, doc_id, notes, source_path)
-                  </label>
-                  <input
-                    id="descriptorTemplate"
-                    className="admin-prompts__input"
-                    value={activeConfig.attachmentDescriptorTemplate}
-                    onChange={(event) => handleDescriptorTemplateChange(event.target.value)}
-                  />
-                </div>
-
-                <section className="admin-prompts__group">
-                  <header className="admin-prompts__group-header">
-                    <h3 className="admin-prompts__group-title">내장 컨텍스트</h3>
-                    <button type="button" className="admin-prompts__secondary" onClick={handleAddBuiltinContext}>
-                      + 컨텍스트 추가
-                    </button>
-                  </header>
-                  {activeConfig.builtinContexts.length === 0 ? (
-                    <p className="admin-prompts__empty">등록된 내장 컨텍스트가 없습니다.</p>
-                  ) : (
-                    <ul className="admin-prompts__list">
-                      {activeConfig.builtinContexts.map((context) => (
-                        <li key={context.id} className="admin-prompts__list-item">
-                          <div className="admin-prompts__field">
-                            <label className="admin-prompts__label" htmlFor={`${context.id}-label`}>
-                              이름
-                            </label>
-                            <input
-                              id={`${context.id}-label`}
-                              className="admin-prompts__input"
-                              value={context.label}
-                              onChange={(event) => handleBuiltinContextChange(context.id, 'label', event.target.value)}
-                            />
-                          </div>
-                          <div className="admin-prompts__field">
-                            <label className="admin-prompts__label" htmlFor={`${context.id}-description`}>
-                              설명
-                            </label>
-                            <textarea
-                              id={`${context.id}-description`}
-                              className="admin-prompts__textarea"
-                              value={context.description}
-                              onChange={(event) => handleBuiltinContextChange(context.id, 'description', event.target.value)}
-                            />
-                          </div>
-                          <div className="admin-prompts__field">
-                            <label className="admin-prompts__label" htmlFor={`${context.id}-source`}>
-                              파일 경로
-                            </label>
-                            <input
-                              id={`${context.id}-source`}
-                              className="admin-prompts__input"
-                              value={context.sourcePath}
-                              onChange={(event) => handleBuiltinContextChange(context.id, 'sourcePath', event.target.value)}
-                            />
-                          </div>
-                          <div className="admin-prompts__field">
-                            <label className="admin-prompts__label" htmlFor={`${context.id}-render`}>
-                              렌더링 방식
-                            </label>
-                            <select
-                              id={`${context.id}-render`}
-                              className="admin-prompts__select"
-                              value={context.renderMode}
-                              onChange={(event) =>
-                                handleBuiltinContextChange(context.id, 'renderMode', event.target.value as PromptBuiltinContext['renderMode'])
-                              }
+                            <button
+                              type="button"
+                              className="admin-prompts__remove"
+                              onClick={() => handleRemoveSection(section.id)}
+                              aria-label="지침 삭제"
                             >
-                              <option value="file">파일 그대로</option>
-                              <option value="image">이미지</option>
-                              <option value="xlsx-to-pdf">XLSX → PDF</option>
-                              <option value="text">텍스트</option>
-                            </select>
-                          </div>
-                          <div className="admin-prompts__toggles">
-                            <label className="admin-prompts__switch">
+                              삭제
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+
+                  <section className="admin-prompts__group">
+                    <h3 className="admin-prompts__group-title">첨부 안내 문구</h3>
+                    <div className="admin-prompts__field-grid">
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor="attachmentsHeading">섹션 제목</label>
+                        <input
+                          id="attachmentsHeading"
+                          className="admin-prompts__input"
+                          value={activeConfig.scaffolding.attachmentsHeading}
+                          onChange={(event) => handleScaffoldingChange('attachmentsHeading', event.target.value)}
+                        />
+                      </div>
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor="attachmentsIntro">소개 문구</label>
+                        <textarea
+                          id="attachmentsIntro"
+                          className="admin-prompts__textarea"
+                          value={activeConfig.scaffolding.attachmentsIntro}
+                          onChange={(event) => handleScaffoldingChange('attachmentsIntro', event.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="admin-prompts__field-grid">
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor="closingNote">
+                          마무리 문장 ({'{'}context_summary{'}'} 사용 가능)
+                        </label>
+                        <textarea
+                          id="closingNote"
+                          className="admin-prompts__textarea"
+                          value={activeConfig.scaffolding.closingNote}
+                          onChange={(event) => handleScaffoldingChange('closingNote', event.target.value)}
+                        />
+                      </div>
+                      <div className="admin-prompts__field">
+                        <label className="admin-prompts__label" htmlFor="formatWarning">형식 경고</label>
+                        <textarea
+                          id="formatWarning"
+                          className="admin-prompts__textarea"
+                          value={activeConfig.scaffolding.formatWarning}
+                          onChange={(event) => handleScaffoldingChange('formatWarning', event.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </section>
+
+                  <div className="admin-prompts__field">
+                    <label className="admin-prompts__label" htmlFor="descriptorTemplate">
+                      첨부 설명 템플릿 (사용 가능 키: index, descriptor, label, description, extension, doc_id, notes, source_path)
+                    </label>
+                    <input
+                      id="descriptorTemplate"
+                      className="admin-prompts__input"
+                      value={activeConfig.attachmentDescriptorTemplate}
+                      onChange={(event) => handleDescriptorTemplateChange(event.target.value)}
+                    />
+                  </div>
+
+                  <section className="admin-prompts__group">
+                    <header className="admin-prompts__group-header">
+                      <h3 className="admin-prompts__group-title">내장 컨텍스트</h3>
+                      <button type="button" className="admin-prompts__secondary" onClick={handleAddBuiltinContext}>
+                        + 컨텍스트 추가
+                      </button>
+                    </header>
+                    {activeConfig.builtinContexts.length === 0 ? (
+                      <p className="admin-prompts__empty">등록된 내장 컨텍스트가 없습니다.</p>
+                    ) : (
+                      <ul className="admin-prompts__list">
+                        {activeConfig.builtinContexts.map((context) => (
+                          <li key={context.id} className="admin-prompts__list-item">
+                            <div className="admin-prompts__field">
+                              <label className="admin-prompts__label" htmlFor={`${context.id}-label`}>
+                                이름
+                              </label>
                               <input
-                                type="checkbox"
-                                checked={context.includeInPrompt}
-                                onChange={(event) => handleToggleBuiltinContext(context.id, 'includeInPrompt', event.target.checked)}
+                                id={`${context.id}-label`}
+                                className="admin-prompts__input"
+                                value={context.label}
+                                onChange={(event) => handleBuiltinContextChange(context.id, 'label', event.target.value)}
                               />
-                              <span>첨부에 포함</span>
-                            </label>
-                            <label className="admin-prompts__switch">
+                            </div>
+                            <div className="admin-prompts__field">
+                              <label className="admin-prompts__label" htmlFor={`${context.id}-description`}>
+                                설명
+                              </label>
+                              <textarea
+                                id={`${context.id}-description`}
+                                className="admin-prompts__textarea"
+                                value={context.description}
+                                onChange={(event) => handleBuiltinContextChange(context.id, 'description', event.target.value)}
+                              />
+                            </div>
+                            <div className="admin-prompts__field">
+                              <label className="admin-prompts__label" htmlFor={`${context.id}-source`}>
+                                파일 경로
+                              </label>
                               <input
-                                type="checkbox"
-                                checked={context.showInAttachmentList}
+                                id={`${context.id}-source`}
+                                className="admin-prompts__input"
+                                value={context.sourcePath}
+                                onChange={(event) => handleBuiltinContextChange(context.id, 'sourcePath', event.target.value)}
+                              />
+                            </div>
+                            <div className="admin-prompts__field">
+                              <label className="admin-prompts__label" htmlFor={`${context.id}-render`}>
+                                렌더링 방식
+                              </label>
+                              <select
+                                id={`${context.id}-render`}
+                                className="admin-prompts__select"
+                                value={context.renderMode}
                                 onChange={(event) =>
-                                  handleToggleBuiltinContext(context.id, 'showInAttachmentList', event.target.checked)
+                                  handleBuiltinContextChange(
+                                    context.id,
+                                    'renderMode',
+                                    event.target.value as PromptBuiltinContext['renderMode'],
+                                  )
                                 }
-                              />
-                              <span>목록에 표시</span>
-                            </label>
-                          </div>
-                          <button
-                            type="button"
-                            className="admin-prompts__remove"
-                            onClick={() => handleRemoveBuiltinContext(context.id)}
-                            aria-label="내장 컨텍스트 삭제"
-                          >
-                            삭제
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
+                              >
+                                <option value="file">파일 그대로</option>
+                                <option value="image">이미지</option>
+                                <option value="xlsx-to-pdf">XLSX → PDF</option>
+                                <option value="text">텍스트</option>
+                              </select>
+                            </div>
+                            <div className="admin-prompts__toggles">
+                              <label className="admin-prompts__switch">
+                                <input
+                                  type="checkbox"
+                                  checked={context.includeInPrompt}
+                                  onChange={(event) => handleToggleBuiltinContext(context.id, 'includeInPrompt', event.target.checked)}
+                                />
+                                <span>첨부에 포함</span>
+                              </label>
+                              <label className="admin-prompts__switch">
+                                <input
+                                  type="checkbox"
+                                  checked={context.showInAttachmentList}
+                                  onChange={(event) =>
+                                    handleToggleBuiltinContext(context.id, 'showInAttachmentList', event.target.checked)
+                                  }
+                                />
+                                <span>목록에 표시</span>
+                              </label>
+                            </div>
+                            <button
+                              type="button"
+                              className="admin-prompts__remove"
+                              onClick={() => handleRemoveBuiltinContext(context.id)}
+                              aria-label="내장 컨텍스트 삭제"
+                            >
+                              삭제
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+
+                  <section className="admin-prompts__group">
+                    <h3 className="admin-prompts__group-title">모델 파라미터</h3>
+                    <div className="admin-prompts__model-grid">
+                      <label className="admin-prompts__model-field">
+                        <span>Temperature</span>
+                        <input
+                          type="number"
+                          step="0.05"
+                          value={activeConfig.modelParameters.temperature}
+                          onChange={(event) => handleModelParameterChange('temperature', Number(event.target.value))}
+                        />
+                      </label>
+                      <label className="admin-prompts__model-field">
+                        <span>Top-p</span>
+                        <input
+                          type="number"
+                          step="0.05"
+                          value={activeConfig.modelParameters.topP}
+                          onChange={(event) => handleModelParameterChange('topP', Number(event.target.value))}
+                        />
+                      </label>
+                      <label className="admin-prompts__model-field">
+                        <span>Max Output Tokens</span>
+                        <input
+                          type="number"
+                          value={activeConfig.modelParameters.maxOutputTokens}
+                          onChange={(event) => handleModelParameterChange('maxOutputTokens', Number(event.target.value))}
+                        />
+                      </label>
+                      <label className="admin-prompts__model-field">
+                        <span>Presence Penalty</span>
+                        <input
+                          type="number"
+                          step="0.1"
+                          value={activeConfig.modelParameters.presencePenalty}
+                          onChange={(event) => handleModelParameterChange('presencePenalty', Number(event.target.value))}
+                        />
+                      </label>
+                      <label className="admin-prompts__model-field">
+                        <span>Frequency Penalty</span>
+                        <input
+                          type="number"
+                          step="0.1"
+                          value={activeConfig.modelParameters.frequencyPenalty}
+                          onChange={(event) => handleModelParameterChange('frequencyPenalty', Number(event.target.value))}
+                        />
+                      </label>
+                    </div>
+                  </section>
+
+                  {status.message && (
+                    <div className={`admin-prompts__status admin-prompts__status--${status.type}`}>
+                      {status.message}
+                    </div>
                   )}
-                </section>
 
-                <section className="admin-prompts__group">
-                  <h3 className="admin-prompts__group-title">모델 파라미터</h3>
-                  <div className="admin-prompts__model-grid">
-                    <label className="admin-prompts__model-field">
-                      <span>Temperature</span>
-                      <input
-                        type="number"
-                        step="0.05"
-                        value={activeConfig.modelParameters.temperature}
-                        onChange={(event) => handleModelParameterChange('temperature', Number(event.target.value))}
-                      />
-                    </label>
-                    <label className="admin-prompts__model-field">
-                      <span>Top-p</span>
-                      <input
-                        type="number"
-                        step="0.05"
-                        value={activeConfig.modelParameters.topP}
-                        onChange={(event) => handleModelParameterChange('topP', Number(event.target.value))}
-                      />
-                    </label>
-                    <label className="admin-prompts__model-field">
-                      <span>Max Output Tokens</span>
-                      <input
-                        type="number"
-                        value={activeConfig.modelParameters.maxOutputTokens}
-                        onChange={(event) => handleModelParameterChange('maxOutputTokens', Number(event.target.value))}
-                      />
-                    </label>
-                    <label className="admin-prompts__model-field">
-                      <span>Presence Penalty</span>
-                      <input
-                        type="number"
-                        step="0.1"
-                        value={activeConfig.modelParameters.presencePenalty}
-                        onChange={(event) => handleModelParameterChange('presencePenalty', Number(event.target.value))}
-                      />
-                    </label>
-                    <label className="admin-prompts__model-field">
-                      <span>Frequency Penalty</span>
-                      <input
-                        type="number"
-                        step="0.1"
-                        value={activeConfig.modelParameters.frequencyPenalty}
-                        onChange={(event) => handleModelParameterChange('frequencyPenalty', Number(event.target.value))}
-                      />
-                    </label>
+                  <div className="admin-prompts__actions">
+                    <button type="button" className="admin-prompts__primary" onClick={handleSave} disabled={saving}>
+                      {saving ? '저장 중...' : '저장'}
+                    </button>
+                    <button type="button" className="admin-prompts__secondary" onClick={handleRevert} disabled={saving}>
+                      되돌리기
+                    </button>
+                    <button type="button" className="admin-prompts__secondary" onClick={handleRestoreDefault} disabled={saving}>
+                      기본값 적용
+                    </button>
                   </div>
-                </section>
-
-                {status.message && (
-                  <div className={`admin-prompts__status admin-prompts__status--${status.type}`}>
-                    {status.message}
-                  </div>
-                )}
-
-                <div className="admin-prompts__actions">
-                  <button
-                    type="button"
-                    className="admin-prompts__secondary"
-                    onClick={() => setPreviewOpen(true)}
-                    disabled={!activeConfig}
-                  >
-                    미리보기
-                  </button>
-                  <button type="button" className="admin-prompts__primary" onClick={handleSave} disabled={saving}>
-                    {saving ? '저장 중...' : '저장'}
-                  </button>
-                  <button type="button" className="admin-prompts__secondary" onClick={handleRevert} disabled={saving}>
-                    되돌리기
-                  </button>
-                  <button type="button" className="admin-prompts__secondary" onClick={handleRestoreDefault} disabled={saving}>
-                    기본값 적용
-                  </button>
                 </div>
               </div>
+            </section>
 
-              <aside className="admin-prompts__sidebar">
-                <section className="admin-prompts__hint">
-                  <h4 className="admin-prompts__hint-title">템플릿 팁</h4>
-                  <p className="admin-prompts__hint-text">
-                    첨부 설명 템플릿에는 {'{'}index{'}'}, {'{'}descriptor{'}'}, {'{'}label{'}'}, {'{'}description{'}'}, {'{'}extension{'}'}, {'{'}doc_id{'}'}, {'{'}notes{'}'},
-                    {'{'}source_path{'}'} 키를 사용할 수 있습니다.
-                  </p>
-                </section>
-              </aside>
-            </div>
-          </section>
+            <aside className="admin-prompts__meta" aria-label="보조 패널">
+              <section className="admin-prompts__card admin-prompts__card--preview">
+                <header className="admin-prompts__card-header">
+                  <div>
+                    <h3 className="admin-prompts__card-title">프롬프트 미리보기</h3>
+                    <p className="admin-prompts__card-subtitle">현재 입력한 내용을 실시간으로 확인하세요.</p>
+                  </div>
+                  <div className="admin-prompts__card-actions">
+                    <button
+                      type="button"
+                      className="admin-prompts__tertiary"
+                      onClick={() => setPreviewOpen(true)}
+                      disabled={!preview}
+                    >
+                      전체 보기
+                    </button>
+                    <button
+                      type="button"
+                      className="admin-prompts__tertiary"
+                      onClick={handleCopyPreview}
+                      disabled={!preview}
+                    >
+                      복사
+                    </button>
+                  </div>
+                </header>
+                <div className={`admin-prompts__preview${preview ? '' : ' admin-prompts__preview--empty'}`}>
+                  {preview ? <pre>{preview}</pre> : <p>지침을 입력하면 미리보기가 표시됩니다.</p>}
+                </div>
+                {copyState !== 'idle' && copyMessage && (
+                  <p className={`admin-prompts__feedback admin-prompts__feedback--${copyState}`}>{copyMessage}</p>
+                )}
+              </section>
+
+              <section className="admin-prompts__card admin-prompts__card--history">
+                <header className="admin-prompts__card-header">
+                  <div>
+                    <h3 className="admin-prompts__card-title">최근 편집 기록</h3>
+                    <p className="admin-prompts__card-subtitle">자주 사용하는 템플릿으로 빠르게 이동하세요.</p>
+                  </div>
+                </header>
+                {recentEntries.length === 0 ? (
+                  <p className="admin-prompts__history-empty">아직 편집 기록이 없습니다. 템플릿을 선택해 관리해 보세요.</p>
+                ) : (
+                  <ul className="admin-prompts__history-list">
+                    {recentEntries.map((entry) => (
+                      <li key={entry.id} className="admin-prompts__history-item">
+                        <button
+                          type="button"
+                          className={`admin-prompts__history-button${
+                            entry.id === activeCategory ? ' admin-prompts__history-button--active' : ''
+                          }`}
+                          onClick={() => handleSelectCategory(entry.id)}
+                        >
+                          <span className="admin-prompts__history-label">{entry.label}</span>
+                          <span className="admin-prompts__history-summary">{entry.summary || '설명 없음'}</span>
+                          <span className="admin-prompts__history-time">{formatRelativeTime(entry.visitedAt)}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className="admin-prompts__card admin-prompts__card--hint">
+                <h4 className="admin-prompts__hint-title">템플릿 팁</h4>
+                <p className="admin-prompts__hint-text">
+                  첨부 설명 템플릿에는 {'{'}index{'}'}, {'{'}descriptor{'}'}, {'{'}label{'}'}, {'{'}description{'}'}, {'{'}extension{'}'},
+                  {'{'}doc_id{'}'}, {'{'}notes{'}'}, {'{'}source_path{'}'} 키를 사용할 수 있습니다.
+                </p>
+              </section>
+            </aside>
+          </div>
         </div>
       </div>
       <Modal

--- a/frontend/src/pages/adminPromptsStorage.ts
+++ b/frontend/src/pages/adminPromptsStorage.ts
@@ -1,0 +1,2 @@
+export const LAST_PROJECT_PATH_STORAGE_KEY = 'tta:admin-prompts:last-project-path'
+export const RECENT_PROMPT_STORAGE_KEY = 'tta:admin-prompts:recent-categories'


### PR DESCRIPTION
## Summary
- store the last visited project path and expose a back-to-project control on the admin prompts page
- redesign the admin prompts workspace with inline preview, recent history, and refreshed responsive styling
- add a wide PageLayout variant to support the expanded admin console experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4a610e4a88330aa4c04bae3c953c4