### PR TITLE
Improve admin prompt manager layout and navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -165,6 +165,12 @@
   gap: 2.5rem;
 }
 
+.page--wide {
+  width: min(1280px, 100%);
+  padding: clamp(3rem, 5vw, 4.5rem) clamp(2rem, 4vw, 4rem);
+  gap: 3rem;
+}
+
 .page__header {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -1,5 +1,13 @@
 import type { PropsWithChildren } from 'react'
 
-export function PageLayout({ children }: PropsWithChildren) {
-  return <div className="page">{children}</div>
+type PageLayoutVariant = 'default' | 'wide'
+
+interface PageLayoutProps extends PropsWithChildren {
+  variant?: PageLayoutVariant
+}
+
+export function PageLayout({ children, variant = 'default' }: PageLayoutProps) {
+  const className = variant === 'wide' ? 'page page--wide' : 'page'
+
+  return <div className={className}>{children}</div>
 }

--- a/frontend/src/pages/AdminPromptsPage.css
+++ b/frontend/src/pages/AdminPromptsPage.css
@@ -27,8 +27,8 @@
 
 .admin-prompts__layout {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
-  gap: 28px;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 32px;
   align-items: start;
 }
 
@@ -75,6 +75,43 @@
   line-height: 1.4;
 }
 
+.admin-prompts__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.admin-prompts__toolbar-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.admin-prompts__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--gray-300, #d1d5db);
+  background-color: var(--surface, #fff);
+  color: var(--gray-700, #374151);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 120ms ease, box-shadow 120ms ease, color 120ms ease;
+}
+
+.admin-prompts__back:hover,
+.admin-prompts__back:focus-visible {
+  outline: none;
+  border-color: var(--primary-400, #60a5fa);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.35);
+  color: var(--primary-600, #2563eb);
+}
+
 .admin-prompts__content {
   display: flex;
   flex-direction: column;
@@ -106,8 +143,8 @@
 
 .admin-prompts__content-body {
   display: grid;
-  grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
-  gap: 32px;
+  grid-template-columns: minmax(0, 2.1fr) minmax(360px, 1fr);
+  gap: 36px;
   align-items: start;
 }
 
@@ -438,6 +475,33 @@
   line-height: 1.5;
 }
 
+.admin-prompts__preview {
+  gap: 18px;
+}
+
+.admin-prompts__preview-caption {
+  margin: 0;
+}
+
+.admin-prompts__preview-body {
+  border-radius: 12px;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  background-color: var(--surface, #fff);
+  padding: 16px;
+  max-height: 340px;
+  overflow: auto;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.admin-prompts__preview-body pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+  color: var(--gray-800, #1f2937);
+  font-size: 0.9rem;
+}
+
 .admin-prompts__status {
   padding: 12px 16px;
   border-radius: 10px;
@@ -452,12 +516,6 @@
 .admin-prompts__status--error {
   background-color: rgba(239, 68, 68, 0.12);
   color: #b91c1c;
-}
-
-.admin-prompts__actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
 }
 
 .admin-prompts__primary {
@@ -491,8 +549,8 @@
   }
 
   .admin-prompts__layout {
-    grid-template-columns: 220px minmax(0, 1fr);
-    gap: 20px;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 24px;
   }
 }
 
@@ -511,13 +569,17 @@
 }
 
 @media (max-width: 640px) {
-  .admin-prompts__actions {
+  .admin-prompts__toolbar {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .admin-prompts__secondary,
-  .admin-prompts__primary {
+  .admin-prompts__toolbar-actions {
+    width: 100%;
+  }
+
+  .admin-prompts__toolbar-actions .admin-prompts__secondary,
+  .admin-prompts__toolbar-actions .admin-prompts__primary {
     width: 100%;
   }
 }

--- a/frontend/src/pages/AdminPromptsPage.tsx
+++ b/frontend/src/pages/AdminPromptsPage.tsx
@@ -4,6 +4,7 @@ import { getBackendUrl } from '../config'
 import { PageHeader } from '../components/layout/PageHeader'
 import { PageLayout } from '../components/layout/PageLayout'
 import { Modal } from '../components/Modal'
+import { navigate } from '../navigation'
 
 import './AdminPromptsPage.css'
 
@@ -629,9 +630,13 @@ export function AdminPromptsPage() {
     setStatus({ type: 'success', message: '기본 템플릿을 불러왔습니다.' })
   }
 
+  const handleNavigateProjects = useCallback(() => {
+    navigate('/projects')
+  }, [])
+
   if (loading) {
     return (
-      <PageLayout>
+      <PageLayout variant="wide">
         <div className="admin-prompts admin-prompts--loading">
           <PageHeader
             eyebrow="프롬프트 자산 관리"
@@ -646,7 +651,7 @@ export function AdminPromptsPage() {
 
   if (error || !configs || !activeConfig) {
     return (
-      <PageLayout>
+      <PageLayout variant="wide">
         <div className="admin-prompts admin-prompts--error">
           <PageHeader
             eyebrow="프롬프트 자산 관리"
@@ -660,13 +665,36 @@ export function AdminPromptsPage() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout variant="wide">
       <div className="admin-prompts">
         <PageHeader
           eyebrow="프롬프트 자산 관리"
           title="요청 템플릿 & 첨부 자료 설정"
           subtitle="생성 작업에 사용되는 시스템/사용자 프롬프트와 부가 정보를 실시간으로 조정하세요."
         />
+
+        <div className="admin-prompts__toolbar" role="navigation" aria-label="프롬프트 관리자 작업">
+          <button type="button" className="admin-prompts__back" onClick={handleNavigateProjects}>
+            ← 프로젝트 페이지로 돌아가기
+          </button>
+          <div className="admin-prompts__toolbar-actions">
+            <button type="button" className="admin-prompts__secondary" onClick={handleRestoreDefault} disabled={saving}>
+              기본값 적용
+            </button>
+            <button type="button" className="admin-prompts__secondary" onClick={handleRevert} disabled={saving}>
+              되돌리기
+            </button>
+            <button type="button" className="admin-prompts__primary" onClick={handleSave} disabled={saving}>
+              {saving ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </div>
+
+        {status.message && (
+          <div className={`admin-prompts__status admin-prompts__status--${status.type}`}>
+            {status.message}
+          </div>
+        )}
 
         <div className="admin-prompts__layout">
           <nav className="admin-prompts__nav" aria-label="프롬프트 카테고리">
@@ -982,34 +1010,28 @@ export function AdminPromptsPage() {
                   </div>
                 </section>
 
-                {status.message && (
-                  <div className={`admin-prompts__status admin-prompts__status--${status.type}`}>
-                    {status.message}
-                  </div>
-                )}
-
-                <div className="admin-prompts__actions">
-                  <button
-                    type="button"
-                    className="admin-prompts__secondary"
-                    onClick={() => setPreviewOpen(true)}
-                    disabled={!activeConfig}
-                  >
-                    미리보기
-                  </button>
-                  <button type="button" className="admin-prompts__primary" onClick={handleSave} disabled={saving}>
-                    {saving ? '저장 중...' : '저장'}
-                  </button>
-                  <button type="button" className="admin-prompts__secondary" onClick={handleRevert} disabled={saving}>
-                    되돌리기
-                  </button>
-                  <button type="button" className="admin-prompts__secondary" onClick={handleRestoreDefault} disabled={saving}>
-                    기본값 적용
-                  </button>
-                </div>
               </div>
 
               <aside className="admin-prompts__sidebar">
+                <section className="admin-prompts__group admin-prompts__preview">
+                  <header className="admin-prompts__group-header">
+                    <h3 className="admin-prompts__group-title">실시간 미리보기</h3>
+                    <button
+                      type="button"
+                      className="admin-prompts__secondary"
+                      onClick={() => setPreviewOpen(true)}
+                      disabled={!preview}
+                    >
+                      전체 화면
+                    </button>
+                  </header>
+                  <p className="admin-prompts__logs-caption admin-prompts__preview-caption">
+                    입력한 내용을 바탕으로 생성되는 프롬프트를 즉시 확인하세요.
+                  </p>
+                  <div className="admin-prompts__preview-body">
+                    <pre>{preview || '프롬프트 지시를 입력하면 미리보기 내용이 표시됩니다.'}</pre>
+                  </div>
+                </section>
                 <section className="admin-prompts__group admin-prompts__logs">
                   <header className="admin-prompts__group-header">
                     <h3 className="admin-prompts__group-title">최근 요청 기록</h3>


### PR DESCRIPTION
## Summary
- add a wide variant for the shared page layout so the prompt manager has more horizontal space
- reorganize the admin prompt toolbar with a project return button and repositioned actions
- introduce an inline preview panel and widened sidebar to surface preview and request logs without excessive wrapping

## Testing
- npm run lint *(warnings about existing refs in ProjectManagementPage remain)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ab3c83608330820034fc73abc47b