### PR TITLE
Make testcase scenario cards collapsible and simplify image uploads

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -691,6 +691,11 @@
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
+.file-uploader__dropzone--compact {
+  padding: 1rem 1.25rem;
+  min-height: 96px;
+}
+
 .file-uploader__dropzone--preview {
   align-items: stretch;
   justify-content: flex-start;

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,19 +1,9 @@
-import type { FileType } from './fileUploaderTypes'
 import { Dropzone } from './file-uploader/Dropzone'
 import { FileGrid } from './file-uploader/FileGrid'
 import { FileList } from './file-uploader/FileList'
-import { useFileUploader } from './file-uploader/useFileUploader'
+import { useFileUploader, type UseFileUploaderOptions } from './file-uploader/useFileUploader'
 
-export interface FileUploaderProps {
-  allowedTypes: FileType[]
-  files: File[]
-  onChange: (files: File[]) => void
-  disabled?: boolean
-  multiple?: boolean
-  hideDropzoneWhenFilled?: boolean
-  maxFiles?: number
-  variant?: 'default' | 'grid'
-}
+export interface FileUploaderProps extends UseFileUploaderOptions {}
 
 export function FileUploader(props: FileUploaderProps) {
   const { containerClassName, dropzone, error, grid, list } = useFileUploader(props)

--- a/frontend/src/components/file-uploader/Dropzone.tsx
+++ b/frontend/src/components/file-uploader/Dropzone.tsx
@@ -12,13 +12,46 @@ export function Dropzone({
   onDragOver,
   onDragLeave,
   onDrop,
+  onPaste,
+  enableDragAndDrop,
+  allowPaste,
 }: DropzoneProps) {
   if (!shouldRender) {
     return null
   }
 
+  const helperText = enableDragAndDrop
+    ? '이미지를 클릭해서 추가하거나 드래그 앤 드롭하세요.'
+    : allowPaste
+      ? '이미지를 클릭해서 추가하거나 붙여넣기(Ctrl+V)를 사용하세요.'
+      : '이미지를 클릭해서 추가하세요.'
+
+  const prompt = enableDragAndDrop ? (
+    <>
+      <div className="file-uploader__prompt">
+        <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
+      </div>
+      <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
+    </>
+  ) : (
+    <>
+      <div className="file-uploader__prompt">
+        {allowPaste
+          ? '파일을 클릭해서 선택하거나 붙여넣기(Ctrl+V)로 추가하세요.'
+          : '파일을 클릭해서 선택하세요.'}
+      </div>
+      <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
+    </>
+  )
+
   return (
-    <label className={className} onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
+    <label
+      className={className}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onPaste={onPaste}
+    >
       <input type="file" className="file-uploader__input" {...inputProps} />
       {shouldRenderCompactPreview && files.length > 0 ? (
         <>
@@ -46,17 +79,10 @@ export function Dropzone({
               </div>
             ))}
           </div>
-          <div className="file-uploader__preview-helper" aria-hidden="true">
-            이미지를 클릭해서 추가하거나 드래그 앤 드롭하세요.
-          </div>
+          <div className="file-uploader__preview-helper" aria-hidden="true">{helperText}</div>
         </>
       ) : (
-        <>
-          <div className="file-uploader__prompt">
-            <strong>파일을 드래그 앤 드롭</strong>하거나 클릭해서 선택하세요.
-          </div>
-          <div className="file-uploader__help">허용된 형식: {allowedLabels}</div>
-        </>
+        prompt
       )}
     </label>
   )

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
@@ -141,6 +141,7 @@
   gap: 0.5rem;
   color: #475569;
   font-size: 0.9rem;
+  flex-wrap: wrap;
 }
 
 .testcase-workflow__card-meta-count {
@@ -149,6 +150,28 @@
   background: #eef2ff;
   color: #312e81;
   font-weight: 600;
+}
+
+.testcase-workflow__card--collapsed {
+  background: #ffffff;
+}
+
+.testcase-workflow__card--collapsed .testcase-workflow__card-header {
+  margin-bottom: 0;
+}
+
+.testcase-workflow__card-name {
+  margin: 0.35rem 0 0;
+  display: flex;
+  gap: 0.4rem;
+  align-items: baseline;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.testcase-workflow__card-name-value {
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .testcase-workflow__card-body {
@@ -176,7 +199,7 @@
 }
 
 .testcase-workflow__attachments .file-uploader__dropzone {
-  min-height: 140px;
+  min-height: 100px;
 }
 
 .testcase-workflow__attachments-title {
@@ -390,6 +413,8 @@
 .testcase-workflow__chat-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .testcase-workflow__chat .testcase-workflow__textarea {


### PR DESCRIPTION
## Summary
- allow testcase scenario cards to be collapsed after marking them 완료 and re-opened via a 수정 action
- keep collapsed cards focused on the 소분류 배지, 생성된 시나리오 카운트, and 기능명 summary
- shrink the 참고 이미지 업로더, remove drag-and-drop requirements, and support click or Ctrl+V image uploads

## Testing
- npm run test -- --runInBand *(fails: vitest binary unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf04f911c83308bacbd4c7a5b3da2