### PR TITLE
Add dedicated defect report edit page workflow

### DIFF
--- a/backend/app/services/google_drive/defect_reports.py
+++ b/backend/app/services/google_drive/defect_reports.py
@@ -1,14 +1,384 @@
-"""Helpers related to Drive defect report workflows."""
-from __future__ import annotations
+import csv
+import io
+import logging
+from functools import cmp_to_key
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
-from typing import Any, Dict, Iterable, List
+from fastapi import HTTPException
 
-from ..excel_templates.models import DEFECT_REPORT_EXPECTED_HEADERS, DefectReportImage
+try:  # pragma: no cover - optional dependency
+    from openpyxl import load_workbook
+except ImportError:  # pragma: no cover
+    load_workbook = None  # type: ignore[assignment]
+
+from ..excel_templates.models import (
+    DEFECT_REPORT_EXPECTED_HEADERS,
+    DEFECT_REPORT_START_ROW,
+    DefectReportImage,
+)
+from .naming import drive_name_matches, looks_like_header_row
 
 __all__ = [
     "DEFECT_REPORT_EXPECTED_HEADERS",
+    "parse_defect_report_workbook",
+    "build_defect_report_rows_csv",
+    "prepare_defect_report_response",
+    "normalize_defect_report_rows",
     "serialize_defect_report_images",
 ]
+
+logger = logging.getLogger(__name__)
+
+_DEFECT_SHEET_CANDIDATES: Tuple[str, ...] = (
+    "결함리포트",
+    "결함 리포트",
+    "defect report",
+    "defect_report",
+)
+
+_FIELD_KEY_MAP: Dict[str, str] = {
+    "순번": "order",
+    "시험환경(OS)": "environment",
+    "시험환경 OS": "environment",
+    "시험 환경": "environment",
+    "시험환경": "environment",
+    "결함요약": "summary",
+    "결함 요약": "summary",
+    "결함정도": "severity",
+    "결함 정도": "severity",
+    "발생빈도": "frequency",
+    "발생 빈도": "frequency",
+    "품질특성": "quality",
+    "품질 특성": "quality",
+    "결함 설명": "description",
+    "업체 응답": "vendorResponse",
+    "수정여부": "fixStatus",
+    "수정 여부": "fixStatus",
+    "비고": "note",
+}
+
+_COLUMN_HEADERS: Dict[str, str] = {
+    "order": "순번",
+    "environment": "시험환경(OS)",
+    "summary": "결함요약",
+    "severity": "결함정도",
+    "frequency": "발생빈도",
+    "quality": "품질특성",
+    "description": "결함 설명",
+    "vendorResponse": "업체 응답",
+    "fixStatus": "수정여부",
+    "note": "비고",
+}
+
+_DEFAULT_ROW: Dict[str, str] = {
+    "order": "",
+    "environment": "시험환경 모든 OS",
+    "summary": "",
+    "severity": "",
+    "frequency": "",
+    "quality": "",
+    "description": "",
+    "vendorResponse": "",
+    "fixStatus": "",
+    "note": "",
+}
+
+_QUALITY_ORDER: Tuple[str, ...] = (
+    "기능적합성",
+    "성능효율성",
+    "호환성",
+    "사용성",
+    "신뢰성",
+    "보안성",
+    "유지보수성",
+    "이식성",
+    "일반적 요구사항",
+)
+
+_SEVERITY_ORDER: Dict[str, int] = {"H": 0, "M": 1, "L": 2}
+
+
+def _normalize_value(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return text.strip()
+
+
+def _normalize_key(key: str) -> str:
+    return key.strip().lower().replace(" ", "")
+
+
+def _quality_rank(value: str) -> int:
+    text = value.strip()
+    if not text:
+        return len(_QUALITY_ORDER)
+    for index, label in enumerate(_QUALITY_ORDER):
+        if text == label:
+            return index
+    normalized = text.replace(" ", "")
+    for index, label in enumerate(_QUALITY_ORDER):
+        if normalized == label.replace(" ", ""):
+            return index
+    return len(_QUALITY_ORDER)
+
+
+def _severity_rank(value: str) -> int:
+    normalized = value.strip().upper()
+    return _SEVERITY_ORDER.get(normalized, len(_SEVERITY_ORDER))
+
+
+def _compare_rows(left: Dict[str, str], right: Dict[str, str]) -> int:
+    quality_left = _quality_rank(left.get("quality", ""))
+    quality_right = _quality_rank(right.get("quality", ""))
+    if quality_left != quality_right:
+        return -1 if quality_left < quality_right else 1
+
+    severity_left = _severity_rank(left.get("severity", ""))
+    severity_right = _severity_rank(right.get("severity", ""))
+    if severity_left != severity_right:
+        return -1 if severity_left < severity_right else 1
+
+    env_left = left.get("environment", "")
+    env_right = right.get("environment", "")
+    if env_left != env_right:
+        return -1 if env_left > env_right else 1
+
+    summary_left = left.get("summary", "")
+    summary_right = right.get("summary", "")
+    if summary_left != summary_right:
+        return -1 if summary_left > summary_right else 1
+
+    description_left = left.get("description", "")
+    description_right = right.get("description", "")
+    if description_left != description_right:
+        return -1 if description_left > description_right else 1
+
+    return 0
+
+
+def _detect_severity(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    upper = normalized.upper()
+    if upper in {"H", "M", "L"}:
+        return upper
+
+    compact = upper.replace(" ", "")
+    if any(token in compact for token in ["HIGH", "CRITICAL", "치명", "중대", "심각", "높음"]):
+        return "H"
+    if any(token in compact for token in ["MEDIUM", "중간", "보통", "일반"]):
+        return "M"
+    if any(token in compact for token in ["LOW", "경미", "낮음", "사소", "경미함", "미미"]):
+        return "L"
+    return normalized
+
+
+def _detect_frequency(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    upper = normalized.upper()
+    if upper in {"A", "R"}:
+        return upper
+
+    compact = upper.replace(" ", "")
+    if any(token in compact for token in ["ALWAYS", "항상", "항시", "상시", "지속", "매번", "항구"]):
+        return "A"
+    if any(token in compact for token in ["INTERMITTENT", "SOMETIMES", "OCCASIONAL", "RARE", "간헐", "가끔", "드물", "재현", "비정기", "때때로", "조건부"]):
+        return "R"
+    return normalized
+
+
+def _normalize_quality(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    compact = normalized.replace(" ", "")
+    for label in _QUALITY_ORDER:
+        if compact == label.replace(" ", ""):
+            return label
+    return normalized
+
+
+def normalize_defect_record(entry: Mapping[str, Any]) -> Dict[str, str]:
+    record = dict(_DEFAULT_ROW)
+
+    for key in _COLUMN_HEADERS:
+        if key in entry:
+            record[key] = _normalize_value(entry.get(key))
+
+    for header, key in _FIELD_KEY_MAP.items():
+        if header not in entry:
+            continue
+        value = _normalize_value(entry.get(header))
+        record[key] = value
+
+    record["environment"] = "시험환경 모든 OS"
+    record["vendorResponse"] = ""
+    record["severity"] = _detect_severity(record.get("severity", ""))
+    record["frequency"] = _detect_frequency(record.get("frequency", ""))
+    record["quality"] = _normalize_quality(record.get("quality", ""))
+    return record
+
+
+def normalize_defect_report_rows(rows: Sequence[Mapping[str, Any]]) -> List[Dict[str, str]]:
+    normalized = [normalize_defect_record(row) for row in rows if row]
+    normalized.sort(key=cmp_to_key(_compare_rows))
+
+    for index, row in enumerate(normalized, start=1):
+        row["order"] = str(index)
+    return normalized
+
+
+def parse_defect_report_workbook(workbook_bytes: bytes) -> Tuple[str, int, List[str], List[Dict[str, str]]]:
+    if load_workbook is None:  # pragma: no cover
+        raise HTTPException(status_code=500, detail="openpyxl 패키지가 필요합니다.")
+
+    buffer = io.BytesIO(workbook_bytes)
+    try:
+        workbook = load_workbook(buffer, data_only=True)
+    except Exception as exc:  # pragma: no cover - safety net
+        raise HTTPException(status_code=500, detail="엑셀 파일을 읽는 중 오류가 발생했습니다.") from exc
+
+    headers = list(DEFECT_REPORT_EXPECTED_HEADERS)
+    extracted_rows: List[Dict[str, str]] = []
+    sheet_title = ""
+    start_row = DEFECT_REPORT_START_ROW
+    try:
+        sheet = workbook.active
+        selected_title = sheet.title
+        for candidate in _DEFECT_SHEET_CANDIDATES:
+            matched = False
+            for title in workbook.sheetnames:
+                if drive_name_matches(title, candidate):
+                    try:
+                        sheet = workbook[title]
+                        selected_title = sheet.title
+                        matched = True
+                        break
+                    except KeyError:
+                        continue
+            if matched:
+                break
+
+        sheet_title = selected_title or ""
+        max_col = max(len(headers), sheet.max_column or len(headers))
+        header_row_values: Optional[Sequence[Any]] = None
+        header_row_index: Optional[int] = None
+        column_map: Dict[str, int] = {}
+
+        for idx, row in enumerate(
+            sheet.iter_rows(min_row=1, max_col=max_col, values_only=True),
+            start=1,
+        ):
+            row_values: Sequence[Any] = row if isinstance(row, Sequence) else tuple()
+            if not any(value is not None for value in row_values):
+                continue
+
+            if header_row_values is None:
+                normalized_values = [_normalize_value(value) for value in row_values]
+                if looks_like_header_row(normalized_values, headers):
+                    header_row_values = normalized_values
+                    header_row_index = idx
+                    for col_index, cell_value in enumerate(normalized_values):
+                        normalized_key = _normalize_key(cell_value)
+                        for candidate, mapped_key in _FIELD_KEY_MAP.items():
+                            if _normalize_key(candidate) == normalized_key:
+                                column_map[mapped_key] = col_index
+                                break
+                    continue
+
+            if header_row_values is None:
+                continue
+
+            if not column_map:
+                for candidate, mapped_key in _FIELD_KEY_MAP.items():
+                    normalized_candidate = _normalize_key(candidate)
+                    for col_index, cell_value in enumerate(header_row_values):
+                        if _normalize_key(cell_value) == normalized_candidate:
+                            column_map[mapped_key] = col_index
+                            break
+                if not column_map:
+                    for index, header in enumerate(headers):
+                        mapped_key = _FIELD_KEY_MAP.get(header)
+                        if mapped_key:
+                            column_map[mapped_key] = index
+
+            if looks_like_header_row(row_values, headers):
+                continue
+
+            row_data: Dict[str, str] = dict(_DEFAULT_ROW)
+            has_value = False
+            for key, header in _COLUMN_HEADERS.items():
+                column_index = column_map.get(key)
+                if column_index is None:
+                    continue
+                value = (
+                    row_values[column_index]
+                    if column_index < len(row_values)
+                    else None
+                )
+                text = _normalize_value(value)
+                if text:
+                    has_value = True
+                row_data[key] = text
+
+            if has_value:
+                extracted_rows.append(row_data)
+
+        if header_row_index is not None:
+            start_row = header_row_index + 1
+    finally:
+        workbook.close()
+
+    if not sheet_title:
+        sheet_title = "결함리포트"
+
+    normalized_rows = normalize_defect_report_rows(extracted_rows)
+    return sheet_title, start_row, list(headers), normalized_rows
+
+
+def build_defect_report_rows_csv(rows: Sequence[Mapping[str, Any]]) -> str:
+    normalized_rows = normalize_defect_report_rows(rows)
+
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=list(DEFECT_REPORT_EXPECTED_HEADERS),
+        lineterminator="\n",
+    )
+    writer.writeheader()
+
+    for row in normalized_rows:
+        entry = {header: "" for header in DEFECT_REPORT_EXPECTED_HEADERS}
+        for key, header in _COLUMN_HEADERS.items():
+            entry[header] = row.get(key, "")
+        writer.writerow(entry)
+
+    return output.getvalue()
+
+
+def prepare_defect_report_response(
+    *,
+    file_id: str,
+    file_name: str,
+    sheet_name: str,
+    start_row: int,
+    headers: Sequence[str],
+    rows: Sequence[Mapping[str, Any]],
+    modified_time: Optional[str],
+) -> Dict[str, Any]:
+    return {
+        "fileId": file_id,
+        "fileName": file_name,
+        "sheetName": sheet_name,
+        "startRow": start_row,
+        "headers": list(headers),
+        "rows": [dict(row) for row in rows],
+        "modifiedTime": modified_time,
+    }
 
 
 def serialize_defect_report_images(images: Iterable[DefectReportImage]) -> List[Dict[str, Any]]:
@@ -16,10 +386,10 @@ def serialize_defect_report_images(images: Iterable[DefectReportImage]) -> List[
     for image in images:
         serialized.append(
             {
-                "filename": image.filename,
+                "fileName": image.file_name,
                 "contentType": image.content_type,
-                "size": image.size,
-                "defectIndex": image.defect_index,
+                "size": len(image.content),
             }
         )
     return serialized
+

--- a/frontend/src/app/routing/resolvePage.tsx
+++ b/frontend/src/app/routing/resolvePage.tsx
@@ -6,11 +6,13 @@ import { LoginPage } from '../../pages/LoginPage'
 import { FeatureListEditPage } from '../../pages/FeatureListEditPage'
 import { ProjectManagementPage } from '../../pages/ProjectManagementPage'
 import { TestcaseEditPage } from '../../pages/TestcaseEditPage'
+import { DefectReportEditPage } from '../../pages/DefectReportEditPage'
 import { AdminPromptsPage } from '../../pages/AdminPromptsPage'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/([^/]+)$/
 const FEATURE_LIST_EDIT_PATTERN = /^\/projects\/([^/]+)\/feature-list\/edit$/
 const TESTCASE_EDIT_PATTERN = /^\/projects\/([^/]+)\/testcases\/edit$/
+const DEFECT_REPORT_EDIT_PATTERN = /^\/projects\/([^/]+)\/defect-report\/edit$/
 const PROJECTS_ROOT_PATH = '/projects'
 const LEGACY_DRIVE_PATH = '/drive'
 const ADMIN_PROMPTS_PATH = '/admin/prompts'
@@ -41,6 +43,11 @@ export function resolvePage({ pathname, authStatus }: ResolvePageOptions): React
   const testcaseEditMatch = pathname.match(TESTCASE_EDIT_PATTERN)
   if (testcaseEditMatch) {
     return <TestcaseEditPage projectId={decodeURIComponent(testcaseEditMatch[1])} />
+  }
+
+  const defectEditMatch = pathname.match(DEFECT_REPORT_EDIT_PATTERN)
+  if (defectEditMatch) {
+    return <DefectReportEditPage projectId={decodeURIComponent(defectEditMatch[1])} />
   }
 
   const projectMatch = pathname.match(PROJECT_PATH_PATTERN)

--- a/frontend/src/components/defect-report-workflow/types.ts
+++ b/frontend/src/components/defect-report-workflow/types.ts
@@ -40,7 +40,7 @@ export interface DefectWorkItem {
 export interface DefectReportWorkflowProps {
   backendUrl: string
   projectId: string
-  onPreviewModeChange?: (isPreviewVisible: boolean) => void
+  projectName: string
 }
 
 export interface SelectedCell {

--- a/frontend/src/pages/DefectReportEditPage.css
+++ b/frontend/src/pages/DefectReportEditPage.css
@@ -1,0 +1,245 @@
+.defect-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem 0;
+}
+
+.defect-edit__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.defect-edit__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 0.5rem 0 0;
+}
+
+.defect-edit__meta dt {
+  font-weight: 600;
+  color: #111827;
+}
+
+.defect-edit__meta dd {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.defect-edit__back {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #2563eb;
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0;
+}
+
+.defect-edit__back:hover,
+.defect-edit__back:focus-visible {
+  text-decoration: underline;
+}
+
+.defect-edit__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.defect-edit__description {
+  margin: 0;
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.defect-edit__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.defect-edit__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.defect-edit__file-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.defect-edit__input,
+.defect-edit__textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.defect-edit__input:focus,
+.defect-edit__textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.defect-edit__textarea {
+  min-height: 6.5rem;
+  resize: vertical;
+}
+
+.defect-edit__button {
+  background-color: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.defect-edit__button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.defect-edit__button:not(:disabled):hover,
+.defect-edit__button:not(:disabled):focus-visible {
+  background-color: #1d4ed8;
+  box-shadow: 0 10px 25px -15px rgba(37, 99, 235, 0.7);
+}
+
+.defect-edit__secondary {
+  background-color: transparent;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.defect-edit__secondary:hover,
+.defect-edit__secondary:focus-visible {
+  background-color: rgba(37, 99, 235, 0.08);
+  box-shadow: 0 10px 25px -20px rgba(37, 99, 235, 0.8);
+}
+
+.defect-edit__secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.defect-edit__table-wrapper {
+  overflow-x: auto;
+  border-radius: 0.75rem;
+  border: 1px solid #e5e7eb;
+  background-color: #fff;
+  box-shadow: 0 10px 40px -25px rgba(15, 23, 42, 0.25);
+}
+
+.defect-edit__table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 960px;
+}
+
+.defect-edit__table th,
+.defect-edit__table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+  vertical-align: top;
+  text-align: left;
+  background-color: #fff;
+}
+
+.defect-edit__cell--readonly {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.defect-edit__table th {
+  background-color: #f3f4f6;
+  font-weight: 600;
+  color: #111827;
+  white-space: nowrap;
+}
+
+.defect-edit__status {
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.95rem;
+}
+
+.defect-edit__status--info {
+  background-color: #eef2ff;
+  color: #3730a3;
+}
+
+.defect-edit__status--error {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+.defect-edit__status--success {
+  background-color: #dcfce7;
+  color: #15803d;
+}
+
+.defect-edit__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.defect-edit__loading {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #4b5563;
+}
+
+.defect-edit__actions-cell {
+  text-align: center;
+  white-space: nowrap;
+}
+
+.defect-edit__remove {
+  background-color: transparent;
+  border: 1px solid #ef4444;
+  color: #b91c1c;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.defect-edit__remove:hover,
+.defect-edit__remove:focus-visible {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.defect-edit__remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/DefectReportEditPage.tsx
+++ b/frontend/src/pages/DefectReportEditPage.tsx
@@ -1,0 +1,657 @@
+import './DefectReportEditPage.css'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { getBackendUrl } from '../config'
+import { navigate } from '../navigation'
+
+interface DefectRow {
+  order: string
+  environment: string
+  summary: string
+  severity: string
+  frequency: string
+  quality: string
+  description: string
+  vendorResponse: string
+  fixStatus: string
+  note: string
+}
+
+interface EditableDefectRow extends DefectRow {
+  id: string
+}
+
+interface DefectReportResponse {
+  fileId?: string
+  fileName?: string
+  sheetName?: string
+  startRow?: number
+  headers?: string[]
+  rows?: DefectRow[]
+  modifiedTime?: string
+}
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+type SaveState = 'idle' | 'success' | 'error'
+
+const DEFAULT_HEADERS = [
+  '순번',
+  '시험환경(OS)',
+  '결함요약',
+  '결함정도',
+  '발생빈도',
+  '품질특성',
+  '결함 설명',
+  '업체 응답',
+  '수정여부',
+  '비고',
+]
+
+const COLUMN_CONFIG: Array<{
+  key: keyof DefectRow
+  fallback: string
+  input: 'text' | 'textarea'
+  readOnly?: boolean
+}> = [
+  { key: 'order', fallback: DEFAULT_HEADERS[0], input: 'text', readOnly: true },
+  { key: 'environment', fallback: DEFAULT_HEADERS[1], input: 'text', readOnly: true },
+  { key: 'summary', fallback: DEFAULT_HEADERS[2], input: 'textarea' },
+  { key: 'severity', fallback: DEFAULT_HEADERS[3], input: 'text' },
+  { key: 'frequency', fallback: DEFAULT_HEADERS[4], input: 'text' },
+  { key: 'quality', fallback: DEFAULT_HEADERS[5], input: 'text' },
+  { key: 'description', fallback: DEFAULT_HEADERS[6], input: 'textarea' },
+  { key: 'vendorResponse', fallback: DEFAULT_HEADERS[7], input: 'textarea' },
+  { key: 'fixStatus', fallback: DEFAULT_HEADERS[8], input: 'text' },
+  { key: 'note', fallback: DEFAULT_HEADERS[9], input: 'textarea' },
+]
+
+function normalizeRow(row: Partial<DefectRow> | null | undefined): DefectRow {
+  return {
+    order: typeof row?.order === 'string' ? row.order : '',
+    environment: '시험환경 모든 OS',
+    summary: typeof row?.summary === 'string' ? row.summary : '',
+    severity: typeof row?.severity === 'string' ? row.severity : '',
+    frequency: typeof row?.frequency === 'string' ? row.frequency : '',
+    quality: typeof row?.quality === 'string' ? row.quality : '',
+    description: typeof row?.description === 'string' ? row.description : '',
+    vendorResponse: '',
+    fixStatus: typeof row?.fixStatus === 'string' ? row.fixStatus : '',
+    note: typeof row?.note === 'string' ? row.note : '',
+  }
+}
+
+function createEmptyRow(): DefectRow {
+  return {
+    order: '',
+    environment: '시험환경 모든 OS',
+    summary: '',
+    severity: '',
+    frequency: '',
+    quality: '',
+    description: '',
+    vendorResponse: '',
+    fixStatus: '',
+    note: '',
+  }
+}
+
+function formatTimestamp(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date)
+  } catch {
+    return date.toLocaleString()
+  }
+}
+
+function parseFileNameFromDisposition(disposition: string | null): string | null {
+  if (!disposition) {
+    return null
+  }
+
+  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i)
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1])
+    } catch {
+      return utf8Match[1]
+    }
+  }
+
+  const quotedMatch = disposition.match(/filename="?([^";]+)"?/i)
+  if (quotedMatch?.[1]) {
+    return quotedMatch[1]
+  }
+
+  return null
+}
+
+interface DefectReportEditPageProps {
+  projectId: string
+}
+
+export function DefectReportEditPage({ projectId }: DefectReportEditPageProps) {
+  const backendUrl = useMemo(() => getBackendUrl(), [])
+  const idRef = useRef(0)
+
+  const [fileId, setFileId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') {
+      return null
+    }
+    const params = new URLSearchParams(window.location.search)
+    const value = params.get('fileId')
+    return value && value.trim().length > 0 ? value.trim() : null
+  })
+  const [fileName, setFileName] = useState<string>(() => {
+    if (typeof window === 'undefined') {
+      return 'defect-report.xlsx'
+    }
+    const params = new URLSearchParams(window.location.search)
+    const value = params.get('fileName')
+    return value && value.trim().length > 0 ? value.trim() : 'defect-report.xlsx'
+  })
+  const [sheetName, setSheetName] = useState<string>('결함 리포트')
+  const [headers, setHeaders] = useState<string[]>(() => [...DEFAULT_HEADERS])
+  const [modifiedTime, setModifiedTime] = useState<string | undefined>(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+    const params = new URLSearchParams(window.location.search)
+    const value = params.get('modifiedTime')
+    return value ?? undefined
+  })
+  const [rows, setRows] = useState<EditableDefectRow[]>([])
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isDirty, setIsDirty] = useState<boolean>(false)
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState<boolean>(false)
+  const [isDownloading, setIsDownloading] = useState<boolean>(false)
+  const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [reloadToken, setReloadToken] = useState(0)
+
+  const projectName = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return projectId
+    }
+    const params = new URLSearchParams(window.location.search)
+    return params.get('name') ?? projectId
+  }, [projectId])
+
+  const formattedModified = useMemo(() => formatTimestamp(modifiedTime), [modifiedTime])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setErrorMessage('브라우저 환경에서만 결함 리포트를 수정할 수 있습니다.')
+      setLoadState('error')
+      return
+    }
+
+    const controller = new AbortController()
+    setLoadState('loading')
+    setErrorMessage(null)
+
+    const params = new URLSearchParams(window.location.search)
+    const requestedFileId = params.get('fileId')?.trim() ?? ''
+    const requestedFileName = params.get('fileName')?.trim() ?? ''
+    const requestedModified = params.get('modifiedTime')?.trim() ?? ''
+
+    const searchParams = new URLSearchParams()
+    if (requestedFileId) {
+      searchParams.set('fileId', requestedFileId)
+    }
+
+    async function fetchData() {
+      try {
+        const response = await fetch(
+          `${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/defect-report${
+            searchParams.toString() ? `?${searchParams.toString()}` : ''
+          }`,
+          { signal: controller.signal },
+        )
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null)
+          const detail =
+            payload && typeof payload.detail === 'string'
+              ? payload.detail
+              : '결함 리포트를 불러오는 중 오류가 발생했습니다.'
+          throw new Error(detail)
+        }
+
+        const payload = (await response.json()) as DefectReportResponse
+        if (controller.signal.aborted) {
+          return
+        }
+
+        const nextHeaders = Array.isArray(payload.headers)
+          ? payload.headers.filter((item): item is string => typeof item === 'string')
+          : undefined
+        if (nextHeaders && nextHeaders.length >= DEFAULT_HEADERS.length) {
+          const merged = DEFAULT_HEADERS.map((fallback, index) => {
+            const candidate = nextHeaders[index]
+            if (!candidate || candidate.trim().length === 0) {
+              return fallback
+            }
+            return candidate.trim()
+          })
+          setHeaders(merged)
+        } else {
+          setHeaders([...DEFAULT_HEADERS])
+        }
+
+        setSheetName(payload.sheetName?.trim() || '결함 리포트')
+
+        const effectiveFileName =
+          typeof payload.fileName === 'string' && payload.fileName.trim().length > 0
+            ? payload.fileName.trim()
+            : requestedFileName || 'defect-report.xlsx'
+        setFileName(effectiveFileName)
+
+        const effectiveModified = payload.modifiedTime ?? (requestedModified || undefined)
+        setModifiedTime(effectiveModified || undefined)
+
+        const effectiveFileId =
+          typeof payload.fileId === 'string' && payload.fileId.trim().length > 0
+            ? payload.fileId.trim()
+            : requestedFileId || ''
+        setFileId(effectiveFileId ? effectiveFileId : null)
+
+        const fetchedRows = Array.isArray(payload.rows)
+          ? payload.rows.map((row) => normalizeRow(row))
+          : []
+
+        idRef.current = 0
+        const editableRows: EditableDefectRow[] =
+          fetchedRows.length > 0
+            ? fetchedRows.map((row) => {
+                idRef.current += 1
+                return { id: `row-${idRef.current}`, ...row }
+              })
+            : (() => {
+                idRef.current += 1
+                return [{ id: `row-${idRef.current}`, ...createEmptyRow() }]
+              })()
+
+        setRows(editableRows)
+        setIsDirty(false)
+        setSaveState('idle')
+        setSaveError(null)
+        setDownloadError(null)
+        setLoadState('ready')
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return
+        }
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : '결함 리포트를 불러오는 중 예기치 않은 오류가 발생했습니다.'
+        setErrorMessage(message)
+        setLoadState('error')
+      }
+    }
+
+    fetchData()
+
+    return () => {
+      controller.abort()
+    }
+  }, [backendUrl, projectId, reloadToken])
+
+  const handleRetry = useCallback(() => {
+    setReloadToken((token) => token + 1)
+  }, [])
+
+  const handleBack = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const params = new URLSearchParams(window.location.search)
+    params.delete('fileId')
+    params.delete('fileName')
+    params.delete('modifiedTime')
+    const query = params.toString()
+    navigate(`/projects/${encodeURIComponent(projectId)}${query ? `?${query}` : ''}`)
+  }, [projectId])
+
+  const handleChangeField = useCallback((rowId: string, key: keyof DefectRow, value: string) => {
+    setRows((prev) =>
+      prev.map((row) => (row.id === rowId ? { ...row, [key]: value } : row)),
+    )
+    setIsDirty(true)
+    setSaveState('idle')
+    setSaveError(null)
+  }, [])
+
+  const handleAddRow = useCallback(() => {
+    idRef.current += 1
+    setRows((prev) => [...prev, { id: `row-${idRef.current}`, ...createEmptyRow() }])
+    setIsDirty(true)
+    setSaveState('idle')
+    setSaveError(null)
+  }, [])
+
+  const handleRemoveRow = useCallback((rowId: string) => {
+    setRows((prev) => {
+      if (prev.length <= 1) {
+        return prev
+      }
+      const next = prev.filter((row) => row.id !== rowId)
+      if (next.length === 0) {
+        idRef.current += 1
+        return [{ id: `row-${idRef.current}`, ...createEmptyRow() }]
+      }
+      return next
+    })
+    setIsDirty(true)
+    setSaveState('idle')
+    setSaveError(null)
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    setSaveError(null)
+    setSaveState('idle')
+    try {
+      const payload = {
+        rows: rows.map(({ id, ...rest }) => ({
+          ...rest,
+          environment: '시험환경 모든 OS',
+          vendorResponse: '',
+        })),
+      }
+      const searchParams = new URLSearchParams()
+      if (fileId && fileId.trim().length > 0) {
+        searchParams.set('fileId', fileId)
+      }
+
+      const response = await fetch(
+        `${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/defect-report${
+          searchParams.toString() ? `?${searchParams.toString()}` : ''
+        }`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+      )
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        const detail =
+          data && typeof data.detail === 'string'
+            ? data.detail
+            : '결함 리포트를 저장하는 중 오류가 발생했습니다.'
+        throw new Error(detail)
+      }
+
+      const result = (await response.json().catch(() => ({}))) as DefectReportResponse
+      setIsDirty(false)
+      setSaveState('success')
+      if (typeof result.modifiedTime === 'string' && result.modifiedTime.trim().length > 0) {
+        setModifiedTime(result.modifiedTime.trim())
+      }
+      if (typeof result.fileName === 'string' && result.fileName.trim().length > 0) {
+        setFileName(result.fileName.trim())
+      }
+      if (typeof result.fileId === 'string' && result.fileId.trim().length > 0) {
+        setFileId(result.fileId.trim())
+      }
+      setReloadToken((token) => token + 1)
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : '결함 리포트를 저장하는 중 예기치 않은 오류가 발생했습니다.'
+      setSaveError(message)
+      setSaveState('error')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [backendUrl, fileId, projectId, rows])
+
+  const handleDownload = useCallback(async () => {
+    setIsDownloading(true)
+    setDownloadError(null)
+    try {
+      const searchParams = new URLSearchParams()
+      if (fileId && fileId.trim().length > 0) {
+        searchParams.set('fileId', fileId)
+      }
+
+      const response = await fetch(
+        `${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/defect-report/download${
+          searchParams.toString() ? `?${searchParams.toString()}` : ''
+        }`,
+      )
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        const detail =
+          data && typeof data.detail === 'string'
+            ? data.detail
+            : '결함 리포트 파일을 다운로드하지 못했습니다.'
+        throw new Error(detail)
+      }
+
+      const blob = await response.blob()
+      const disposition = response.headers.get('content-disposition')
+      let downloadName = parseFileNameFromDisposition(disposition) || fileName || 'defect-report.xlsx'
+      if (!downloadName.toLowerCase().endsWith('.xlsx')) {
+        downloadName = `${downloadName.replace(/\.[^./\\]+$/, '')}.xlsx`
+      }
+
+      const objectUrl = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = objectUrl
+      link.download = downloadName
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(objectUrl)
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : '결함 리포트 파일을 다운로드하지 못했습니다.'
+      setDownloadError(message)
+    } finally {
+      setIsDownloading(false)
+    }
+  }, [backendUrl, fileId, fileName, projectId])
+
+  const hasRows = rows.length > 0
+
+  const statusMessage = useMemo(() => {
+    if (saveState === 'success') {
+      return '결함 리포트를 저장했습니다.'
+    }
+    if (saveState === 'error' && saveError) {
+      return saveError
+    }
+    if (downloadError) {
+      return downloadError
+    }
+    return null
+  }, [downloadError, saveError, saveState])
+
+  const statusVariant = useMemo(() => {
+    if (saveState === 'success') {
+      return 'success'
+    }
+    if ((saveState === 'error' && saveError) || downloadError) {
+      return 'error'
+    }
+    return null
+  }, [downloadError, saveError, saveState])
+
+  if (loadState === 'loading') {
+    return (
+      <div className="defect-edit">
+        <div className="defect-edit__loading" role="status">
+          결함 리포트 정보를 불러오고 있습니다…
+        </div>
+      </div>
+    )
+  }
+
+  if (loadState === 'error') {
+    return (
+      <div className="defect-edit">
+        <div className="defect-edit__status defect-edit__status--error" role="alert">
+          {errorMessage || '결함 리포트 정보를 불러올 수 없습니다.'}
+        </div>
+        <div className="defect-edit__actions">
+          <button type="button" className="defect-edit__button" onClick={handleRetry}>
+            다시 시도
+          </button>
+          <button type="button" className="defect-edit__secondary" onClick={handleBack}>
+            프로젝트로 돌아가기
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="defect-edit">
+      <header className="defect-edit__header">
+        <button type="button" className="defect-edit__back" onClick={handleBack}>
+          ← 프로젝트로 돌아가기
+        </button>
+        <h1 className="defect-edit__title">결함 리포트 수정 및 다운로드</h1>
+        <p className="defect-edit__description">
+          {projectName} 프로젝트의 결함 리포트 파일을 검토하고 필요한 변경 사항을 저장한 뒤 엑셀로 다운로드하세요.
+        </p>
+        <dl className="defect-edit__meta">
+          <div>
+            <dt>스프레드시트</dt>
+            <dd>{fileName}</dd>
+          </div>
+          <div>
+            <dt>시트 이름</dt>
+            <dd>{sheetName}</dd>
+          </div>
+          {formattedModified && (
+            <div>
+              <dt>마지막 수정</dt>
+              <dd>{formattedModified}</dd>
+            </div>
+          )}
+        </dl>
+      </header>
+
+      {statusMessage && statusVariant === 'success' && (
+        <div className="defect-edit__status defect-edit__status--success">{statusMessage}</div>
+      )}
+      {statusMessage && statusVariant === 'error' && (
+        <div className="defect-edit__status defect-edit__status--error" role="alert">
+          {statusMessage}
+        </div>
+      )}
+
+      <div className="defect-edit__toolbar" role="group" aria-label="결함 리포트 작업">
+        <button type="button" className="defect-edit__secondary" onClick={handleAddRow}>
+          행 추가
+        </button>
+        <button
+          type="button"
+          className="defect-edit__button"
+          onClick={handleSave}
+          disabled={isSaving || !hasRows || !isDirty}
+        >
+          {isSaving ? '저장 중…' : '변경 사항 저장'}
+        </button>
+        <button
+          type="button"
+          className="defect-edit__button"
+          onClick={handleDownload}
+          disabled={isDownloading || !hasRows}
+        >
+          {isDownloading ? '다운로드 준비 중…' : '엑셀 다운로드'}
+        </button>
+      </div>
+
+      <div className="defect-edit__table-wrapper">
+        {hasRows ? (
+          <table className="defect-edit__table">
+            <thead>
+              <tr>
+                {COLUMN_CONFIG.map((column, index) => (
+                  <th key={column.key}>{headers[index] ?? column.fallback}</th>
+                ))}
+                <th className="defect-edit__actions-cell">작업</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id}>
+                  {COLUMN_CONFIG.map((column) => {
+                    const value = row[column.key]
+                    const label = column.key
+                    if (column.readOnly) {
+                      return (
+                        <td key={label} className="defect-edit__cell defect-edit__cell--readonly">
+                          {value || ''}
+                        </td>
+                      )
+                    }
+                    if (column.input === 'textarea') {
+                      return (
+                        <td key={label}>
+                          <textarea
+                            className="defect-edit__textarea"
+                            value={value}
+                            onChange={(event) =>
+                              handleChangeField(row.id, column.key, event.target.value)
+                            }
+                          />
+                        </td>
+                      )
+                    }
+                    return (
+                      <td key={label}>
+                        <input
+                          className="defect-edit__input"
+                          value={value}
+                          onChange={(event) =>
+                            handleChangeField(row.id, column.key, event.target.value)
+                          }
+                        />
+                      </td>
+                    )
+                  })}
+                  <td className="defect-edit__actions-cell">
+                    <button
+                      type="button"
+                      className="defect-edit__remove"
+                      onClick={() => handleRemoveRow(row.id)}
+                      disabled={rows.length <= 1}
+                    >
+                      삭제
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="defect-edit__status defect-edit__status--info">표시할 결함 리포트가 없습니다.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -257,7 +257,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
     }, {} as Record<MenuItemId, MenuItemContent>)
   }, [])
   const additionalIdRef = useRef(0)
-  const [isDefectPreviewVisible, setIsDefectPreviewVisible] = useState(false)
 
   const releaseDownloadUrl = useCallback((id: MenuItemId, url: string | null) => {
     if (url) {
@@ -275,12 +274,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const handleSelectAnotherProject = useCallback(() => {
     navigate('/projects')
   }, [])
-
-  useEffect(() => {
-    if (!isDefectReport && isDefectPreviewVisible) {
-      setIsDefectPreviewVisible(false)
-    }
-  }, [isDefectReport, isDefectPreviewVisible])
 
   const handleChangeFiles = useCallback(
     (id: MenuItemId, nextFiles: File[]) => {
@@ -737,20 +730,8 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
     }
   }, [])
 
-  const pageClassName = `project-management-page${
-    isDefectReport && isDefectPreviewVisible ? ' project-management-page--preview' : ''
-  }`
-
-  const contentInnerClassName = `project-management-content__inner${
-    isDefectReport && isDefectPreviewVisible ? ' project-management-content__inner--preview' : ''
-  }`
-
-  const contentClassName = `project-management-content${
-    isDefectReport && isDefectPreviewVisible ? ' project-management-content--preview' : ''
-  }`
-
   return (
-    <div className={pageClassName}>
+    <div className="project-management-page">
       <aside className="project-management-sidebar">
         <div className="project-management-overview">
           <span className="project-management-overview__label">프로젝트</span>
@@ -785,8 +766,8 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         </nav>
       </aside>
 
-      <main className={contentClassName} aria-label="프로젝트 관리 컨텐츠">
-        <div className={contentInnerClassName}>
+      <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠">
+        <div className="project-management-content__inner">
           <div className="project-management-content__toolbar" role="navigation" aria-label="프로젝트 작업 메뉴">
             <button
               type="button"
@@ -815,7 +796,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                   <DefectReportWorkflow
                     backendUrl={backendUrl}
                     projectId={projectId}
-                    onPreviewModeChange={setIsDefectPreviewVisible}
+                    projectName={projectName}
                   />
                 ) : hasRequiredDocuments ? (
                   <>


### PR DESCRIPTION
## Summary
- add a dedicated defect report edit page that mirrors the testcase editor UX
- wire the new page into the router, workflow navigation, and backend Drive endpoints
- normalize defect rows to enforce ordering, numbering, and default column values before persisting

## Testing
- npm --prefix frontend run lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68fda752b7988330b841a73c6b5f5b13