### PR TITLE
Handle defect report generation JSON payload

### DIFF
--- a/frontend/src/components/DefectReportWorkflow.tsx
+++ b/frontend/src/components/DefectReportWorkflow.tsx
@@ -16,6 +16,7 @@ import {
 } from './defect-report-workflow/hooks'
 import {
   buildAttachmentFileName,
+  buildRowsFromJsonTable,
   createFileKey,
 } from './defect-report-workflow/utils'
 import { buildPromptResourcesPayload } from './defect-report-workflow/promptResources'
@@ -314,14 +315,12 @@ export function DefectReportWorkflow({
           throw new Error(detail)
         }
 
-        await response.blob()
-
-        const encodedTable = decodeBase64(response.headers.get('x-defect-table'))
-        if (!encodedTable) {
-          throw new Error('생성된 결함 요약을 찾을 수 없습니다.')
+        const payload = (await response.json().catch(() => ({}))) as {
+          rows?: unknown
+          headers?: unknown
         }
 
-        const rows = buildRowsFromCsv(encodedTable)
+        const rows = buildRowsFromJsonTable(payload.headers, payload.rows)
         const row = rows[0]
         if (!row) {
           throw new Error('생성된 결함 요약을 찾을 수 없습니다.')

--- a/frontend/src/components/defect-report-workflow/__tests__/useDefectDownload.test.ts
+++ b/frontend/src/components/defect-report-workflow/__tests__/useDefectDownload.test.ts
@@ -29,11 +29,30 @@ describe('useDefectDownload', () => {
     expect(result.current.downloadError).toBe('다운로드할 리포트가 없습니다.')
   })
 
-  it('stores generated rows and reuses cached downloads', async () => {
+  it('stores generated rows and downloads compiled workbook', async () => {
+    const generatePayload = {
+      fileName: 'defect.xlsx',
+      headers: DEFECT_REPORT_COLUMNS.map((column) => column.key),
+      rows: [
+        {
+          order: '1',
+          summary: 'Issue',
+          severity: 'H',
+          frequency: 'A',
+          quality: '기능적합성',
+          description: '상세 설명',
+        },
+      ],
+    }
+    const generateResponse = new Response(JSON.stringify(generatePayload), {
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+    })
+
     const csvHeader = ['순번', DEFECT_REPORT_COLUMNS[1].key].join(',')
     const csv = `${csvHeader}\n1,Issue\n`
     const base64 = Buffer.from(csv, 'utf-8').toString('base64')
-    const response = new Response('file', {
+    const downloadResponse = new Response('file', {
       status: 200,
       headers: new Headers({
         'content-disposition': "attachment; filename=\"defect.xlsx\"",
@@ -41,7 +60,10 @@ describe('useDefectDownload', () => {
       }),
     })
 
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response as Response)
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(async () => generateResponse as Response)
+      .mockImplementationOnce(async () => downloadResponse as Response)
     const createObjectURLMock = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
@@ -58,8 +80,8 @@ describe('useDefectDownload', () => {
       expect(success).toBe(true)
     })
 
-    expect(fetchMock).toHaveBeenCalled()
-    expect(createObjectURLMock).toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(createObjectURLMock).not.toHaveBeenCalled()
     expect(result.current.tableRows).toHaveLength(1)
 
     await act(async () => {
@@ -67,6 +89,8 @@ describe('useDefectDownload', () => {
       expect(success).toBe(true)
     })
 
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(createObjectURLMock).toHaveBeenCalled()
     expect(result.current.downloadStatus).toBe('success')
   })
 })

--- a/frontend/src/components/defect-report-workflow/hooks.ts
+++ b/frontend/src/components/defect-report-workflow/hooks.ts
@@ -13,6 +13,7 @@ import {
 import {
   buildAttachmentFileName,
   buildRowsFromCsv,
+  buildRowsFromJsonTable,
   createFileKey,
   decodeBase64,
 } from './utils'
@@ -400,39 +401,30 @@ export function useDefectDownload({ backendUrl, projectId }: DownloadOptions) {
           return false
         }
 
-        const blob = await response.blob()
-        const disposition = response.headers.get('content-disposition')
-        let filename = 'defect-report.xlsx'
-        if (disposition) {
-          const match = disposition.match(/filename\*?=([^;]+)/i)
-          if (match) {
-            const value = match[1].replace(/^UTF-8''/i, '')
-            try {
-              filename = decodeURIComponent(value.replace(/"/g, ''))
-            } catch {
-              filename = value.replace(/"/g, '')
-            }
-          }
+        const payload = (await response.json().catch(() => ({}))) as {
+          headers?: unknown
+          rows?: unknown
+          fileName?: unknown
         }
 
-        const encodedTable = decodeBase64(response.headers.get('x-defect-table'))
-        if (encodedTable) {
-          const rows = normalizeDefectRows(buildRowsFromCsv(encodedTable))
-          setTableRows(rows)
-          if (rows.length > 0) {
-            setSelectedCell({ rowIndex: 0, columnKey: DEFECT_REPORT_COLUMNS[0].key })
-          }
+        const rows = normalizeDefectRows(buildRowsFromJsonTable(payload.headers, payload.rows))
+        setTableRows(rows)
+        if (rows.length > 0) {
+          setSelectedCell({ rowIndex: 0, columnKey: DEFECT_REPORT_COLUMNS[0].key })
         }
+
+        const filename =
+          typeof payload?.fileName === 'string' && payload.fileName.trim()
+            ? payload.fileName.trim()
+            : null
 
         if (downloadUrl) {
           URL.revokeObjectURL(downloadUrl)
+          setDownloadUrl(null)
         }
 
-        const objectUrl = URL.createObjectURL(blob)
-        setDownloadUrl(objectUrl)
         setDownloadName(filename)
         setIsTableDirty(false)
-        setDownloadStatus('success')
         setGenerateStatus('success')
         return true
       } catch (error) {

--- a/frontend/src/components/defect-report-workflow/utils.ts
+++ b/frontend/src/components/defect-report-workflow/utils.ts
@@ -1,5 +1,29 @@
 import { DEFECT_REPORT_COLUMNS, DEFECT_REPORT_START_ROW, type DefectReportTableRow } from './types'
 
+const DEFECT_COLUMN_TO_FIELD: Record<string, string> = {
+  순번: 'order',
+  '시험환경(OS)': 'environment',
+  결함요약: 'summary',
+  결함정도: 'severity',
+  발생빈도: 'frequency',
+  품질특성: 'quality',
+  '결함 설명': 'description',
+  '업체 응답': 'vendorResponse',
+  수정여부: 'fixStatus',
+  비고: 'note',
+}
+
+function normalizeKey(key: unknown): string {
+  return typeof key === 'string' ? key.replace(/\s+|[()]/g, '').toLowerCase() : ''
+}
+
+function toCellText(value: unknown): string {
+  if (value == null) {
+    return ''
+  }
+  return typeof value === 'string' ? value : String(value)
+}
+
 export function sanitizeFileName(name: string): string {
   return name.replace(/[\\/:*?"<>|]/g, '_')
 }
@@ -12,6 +36,94 @@ export function buildAttachmentFileName(index: number, original: string): string
 
 export function createFileKey(file: File): string {
   return `${file.name}-${file.size}-${file.lastModified}`
+}
+
+export function buildRowsFromJsonTable(
+  headersInput: unknown,
+  rowsInput: unknown,
+): DefectReportTableRow[] {
+  const headerValues = Array.isArray(headersInput)
+    ? headersInput
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter((value) => value.length > 0)
+    : DEFECT_REPORT_COLUMNS.map((column) => column.key)
+
+  const headerIndex = new Map<string, number>()
+  headerValues.forEach((header, index) => {
+    if (!headerIndex.has(header)) {
+      headerIndex.set(header, index)
+    }
+  })
+
+  const rowsArray = Array.isArray(rowsInput) ? rowsInput : []
+  const tableRows: DefectReportTableRow[] = []
+
+  rowsArray.forEach((rawRow) => {
+    const rowCells: Record<string, string> = {}
+    const rowObject = rawRow && typeof rawRow === 'object' && !Array.isArray(rawRow) ? rawRow : null
+    const normalizedObjectValues = new Map<string, string>()
+
+    if (rowObject) {
+      Object.entries(rowObject as Record<string, unknown>).forEach(([key, value]) => {
+        const normalized = normalizeKey(key)
+        if (normalized && !normalizedObjectValues.has(normalized)) {
+          normalizedObjectValues.set(normalized, toCellText(value))
+        }
+      })
+    }
+
+    DEFECT_REPORT_COLUMNS.forEach((column) => {
+      const headerKey = column.key
+      let value = ''
+
+      if (rowObject) {
+        if (headerKey in (rowObject as Record<string, unknown>)) {
+          value = toCellText((rowObject as Record<string, unknown>)[headerKey])
+        } else {
+          const fieldKey = DEFECT_COLUMN_TO_FIELD[headerKey]
+          if (fieldKey && fieldKey in (rowObject as Record<string, unknown>)) {
+            value = toCellText((rowObject as Record<string, unknown>)[fieldKey])
+          } else {
+            const normalized = normalizeKey(headerKey)
+            const normalizedValue = normalizedObjectValues.get(normalized)
+            if (normalizedValue !== undefined) {
+              value = normalizedValue
+            }
+          }
+        }
+      }
+
+      if (!value) {
+        const index = headerIndex.get(headerKey)
+        if (index !== undefined && Array.isArray(rawRow)) {
+          value = toCellText(rawRow[index])
+        }
+      }
+
+      if (!value && rowObject) {
+        const fieldKey = DEFECT_COLUMN_TO_FIELD[headerKey]
+        if (fieldKey) {
+          const normalizedField = normalizeKey(fieldKey)
+          const normalizedValue = normalizedObjectValues.get(normalizedField)
+          if (normalizedValue !== undefined) {
+            value = normalizedValue
+          }
+        }
+      }
+
+      rowCells[headerKey] = value
+    })
+
+    const hasValue = Object.values(rowCells).some((cell) => cell.trim().length > 0)
+    if (hasValue) {
+      tableRows.push({
+        rowNumber: DEFECT_REPORT_START_ROW + tableRows.length,
+        cells: rowCells,
+      })
+    }
+  })
+
+  return tableRows
 }
 
 export function decodeBase64(value: string | null): string {


### PR DESCRIPTION
## Summary
- switch the defect generation flow to read AI results from the JSON payload instead of the legacy base64 header
- add a utility to translate backend defect rows into the table structure and reuse it from hooks and the workflow component
- update the defect download hook test to cover the JSON response and compiled workbook download path

## Testing
- pnpm test useDefectDownload --runInBand *(fails: vitest: not found)*
- pnpm install *(fails: npm registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fdb2a8c2308330bc1716487216ba31