### PR TITLE
Normalize defect report headers when populating templates

### DIFF
--- a/backend/app/services/excel_templates/utils.py
+++ b/backend/app/services/excel_templates/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import re
 from typing import Dict, Iterable, List, Sequence
 
 __all__ = [
@@ -66,6 +67,17 @@ def append_attachment_note(value: object, names: Sequence[str]) -> str:
     return note
 
 
+def _normalize_header_token(value: str) -> str:
+    cleaned = str(value or "").strip().lower()
+    if not cleaned:
+        return ""
+    cleaned = cleaned.lstrip("\ufeff")
+    cleaned = re.sub(r"[\s\u00a0]+", "", cleaned)
+    cleaned = re.sub(r"[()\[\]{}<>]+", "", cleaned)
+    cleaned = cleaned.replace("-", "").replace("_", "")
+    return cleaned
+
+
 def parse_csv_records(csv_text: str, expected_columns: Sequence[str]) -> List[Dict[str, str]]:
     stripped = csv_text.strip()
     if not stripped:
@@ -80,9 +92,20 @@ def parse_csv_records(csv_text: str, expected_columns: Sequence[str]) -> List[Di
     if header:
         header[0] = header[0].lstrip("\ufeff")
     column_index: Dict[str, int] = {}
+    normalized_lookup: Dict[str, str] = {}
+    for column in expected_columns:
+        normalized = _normalize_header_token(column)
+        if normalized and normalized not in normalized_lookup:
+            normalized_lookup[normalized] = column
+
     for idx, name in enumerate(header):
-        if name:
-            column_index[name] = idx
+        if not name:
+            continue
+        column_index.setdefault(name, idx)
+        normalized = _normalize_header_token(name)
+        canonical = normalized_lookup.get(normalized)
+        if canonical:
+            column_index.setdefault(canonical, idx)
 
     missing = [column for column in expected_columns if column not in column_index]
     if missing:

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -18,6 +18,7 @@ from app.services.excel_templates import (
     SECURITY_REPORT_EXPECTED_HEADERS,
     TESTCASE_EXPECTED_HEADERS,
     extract_feature_list_overview,
+    populate_defect_report,
     populate_feature_list,
     populate_security_report,
     populate_testcase_list,
@@ -183,3 +184,50 @@ def test_populate_security_report_fills_rows() -> None:
     assert _cell_text(root, "E6") == "A"
     assert _cell_text(root, "G6") == "상세 설명"
     assert _cell_text(root, "J6") == "비고"
+
+
+def test_populate_defect_report_accepts_spaced_headers() -> None:
+    template_path = Path("backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    csv_header = ",".join(
+        [
+            "순번",
+            "시험환경 OS",
+            "결함 요약",
+            "결함 정도",
+            "발생 빈도",
+            "품질 특성",
+            "결함 설명",
+            "업체 응답",
+            "수정 여부",
+            "비고",
+        ]
+    )
+    csv_row = ",".join(
+        [
+            "7",
+            "시험환경 모든 OS",
+            "요약 텍스트",
+            "M",
+            "R",
+            "보안성",
+            "상세 설명",
+            "",
+            "",
+            "비고 메모",
+        ]
+    )
+    csv_text = f"{csv_header}\n{csv_row}"
+
+    updated = populate_defect_report(template_bytes, csv_text)
+    root = _load_sheet(updated)
+
+    assert _cell_text(root, "A6") == "7"
+    assert _cell_text(root, "B6") == "시험환경 모든 OS"
+    assert _cell_text(root, "C6") == "요약 텍스트"
+    assert _cell_text(root, "D6") == "M"
+    assert _cell_text(root, "E6") == "R"
+    assert _cell_text(root, "F6") == "보안성"
+    assert _cell_text(root, "G6") == "상세 설명"
+    assert _cell_text(root, "J6") == "비고 메모"


### PR DESCRIPTION
## Summary
- allow defect report CSV parsing to normalize header tokens before mapping them to template columns
- share the header normalization in the workbook utilities so XLSX population accepts variants such as "결함 요약"
- add a regression test confirming spaced headers populate the correct cells in the defect report template

## Testing
- pytest backend/tests/test_excel_population.py backend/tests/test_excel_defect_report.py

------
https://chatgpt.com/codex/tasks/task_e_68fdbfd824648330a5ef2ffecc8e27f6