### PR TITLE
Refactor defect report finalization payload

### DIFF
--- a/frontend/src/components/defect-report-workflow/types.ts
+++ b/frontend/src/components/defect-report-workflow/types.ts
@@ -25,6 +25,12 @@ export interface DefectReportTableRow {
   cells: Record<string, string>
 }
 
+export interface FinalizedDefectRow {
+  index: number
+  cells: Record<string, string>
+  attachmentNames: string[]
+}
+
 export interface DefectWorkItem {
   entry: DefectEntry
   attachments: File[]


### PR DESCRIPTION
## Summary
- add a helper to build finalized defect rows with normalized result cells, attachment-driven environment defaults, and note text
- refactor the defect report finalize hook to accept precomputed rows, upload only image files, and send the new JSON payloads
- introduce a FinalizedDefectRow type to share the finalized row shape across the workflow

## Testing
- npm run lint *(fails: missing @eslint/js in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68fdda71afbc83308bade5ce5f3f9163