### PR TITLE
Add tests and docs for defect report finalize flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Google Drive와 연동된 프로젝트를 생성·선택·관리할 수 있습�
 
   * 선택한 파일과 메뉴 ID를 `/drive/projects/:id/generate`로 전송
   * 중복 요청 방지(AI 호출 시 AbortController 사용)
+* **결함 리포트 최종 반영**
+
+  * `menu_id=defect-report`로 동일 엔드포인트를 호출할 때 정제된 행 데이터를 함께 전송합니다.
+  * `FormData`에는 `rows`(행 목록 JSON)와 `attachment_names`(결함 순번·첨부 파일명 JSON) 필드가 포함됩니다.
+  * 백엔드는 `rows` 필드를 감지하면 OpenAI 호출을 건너뛰고 곧바로 Google 스프레드시트를 업데이트합니다.
 * **CSV 다운로드**
 
   * AI 생성 결과를 CSV 파일로 저장

--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -378,6 +378,12 @@ async def generate_project_asset(
     file_metadata: Optional[str] = Form(
         None, description="업로드된 파일에 대한 메타데이터(JSON 배열)"
     ),
+    serialized_rows: Optional[str] = Form(
+        None, alias="rows", description="결함 리포트 행 데이터(JSON 배열)"
+    ),
+    attachment_stub_metadata: Optional[str] = Form(
+        None, alias="attachment_names", description="결함 첨부 파일명(JSON 배열)"
+    ),
     google_id: Optional[str] = Query(None, description="Drive 작업에 사용할 Google 사용자 식별자 (sub)"),
     ai_generation_service: AIGenerationService = Depends(get_ai_generation_service),
     drive_service: GoogleDriveService = Depends(get_drive_service),
@@ -401,6 +407,79 @@ async def generate_project_asset(
 
     if metadata_entries and len(metadata_entries) != len(uploads):
         raise HTTPException(status_code=422, detail="파일 메타데이터와 업로드된 파일 수가 일치하지 않습니다.")
+
+    if menu_id == "defect-report" and serialized_rows:
+        try:
+            parsed_rows = json.loads(serialized_rows)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=422, detail="결함 리포트 행 데이터 형식이 올바르지 않습니다.") from exc
+
+        if not isinstance(parsed_rows, list) or not parsed_rows:
+            raise HTTPException(status_code=422, detail="결함 리포트 행 데이터 형식이 올바르지 않습니다.")
+
+        normalized_input: List[Dict[str, Any]] = []
+        for index, entry in enumerate(parsed_rows, start=1):
+            if not isinstance(entry, Mapping):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"{index}번째 결함 리포트 행 데이터 형식이 올바르지 않습니다.",
+                )
+            normalized_input.append(dict(entry))
+
+        normalized_rows = drive_defect_reports.normalize_defect_report_rows(normalized_input)
+
+        attachment_notes: Dict[int, List[str]] = {}
+        if attachment_stub_metadata:
+            try:
+                parsed_stubs = json.loads(attachment_stub_metadata)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=422, detail="결함 첨부 파일명 데이터 형식이 올바르지 않습니다.") from exc
+
+            if not isinstance(parsed_stubs, list):
+                raise HTTPException(status_code=422, detail="결함 첨부 파일명 데이터 형식이 올바르지 않습니다.")
+
+            for item in parsed_stubs:
+                if not isinstance(item, Mapping):
+                    raise HTTPException(status_code=422, detail="결함 첨부 파일명 데이터 형식이 올바르지 않습니다.")
+
+                defect_index = item.get("defect_index")
+                try:
+                    normalized_index = int(defect_index)
+                except (TypeError, ValueError):
+                    raise HTTPException(status_code=422, detail="결함 첨부 파일 순번이 올바르지 않습니다.")
+
+                file_name = item.get("fileName") or item.get("file_name")
+                if not isinstance(file_name, str) or not file_name.strip():
+                    raise HTTPException(status_code=422, detail="결함 첨부 파일명이 올바르지 않습니다.")
+
+                attachment_notes.setdefault(normalized_index, []).append(file_name.strip())
+
+        for upload in uploads:
+            await upload.close()
+
+        update_info = await drive_service.update_defect_report_rows(
+            project_id=project_id,
+            rows=normalized_rows,
+            google_id=google_id,
+            images=None,
+            attachment_notes=attachment_notes if attachment_notes else None,
+        )
+
+        file_id = update_info.get("fileId")
+        if not file_id:
+            raise HTTPException(status_code=500, detail="결함 리포트 파일을 업데이트하지 못했습니다. 다시 시도해 주세요.")
+
+        payload: Dict[str, Any] = {
+            "status": "updated",
+            "projectId": project_id,
+            "fileId": file_id,
+            "fileName": update_info.get("fileName"),
+            "modifiedTime": update_info.get("modifiedTime"),
+            "rows": normalized_rows,
+            "headers": list(drive_defect_reports.DEFECT_REPORT_EXPECTED_HEADERS),
+        }
+
+        return JSONResponse(payload)
 
     if menu_id == "security-report":
         if metadata_entries:

--- a/backend/tests/test_drive_defect_finalize.py
+++ b/backend/tests/test_drive_defect_finalize.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.application import create_app
+from app.dependencies import get_ai_generation_service, get_drive_service
+from app.services.google_drive import defect_reports
+
+
+def _create_app_with_mocks():
+    os.environ.setdefault("OPENAI_API_KEY", "test-key")
+    app = create_app()
+
+    ai_stub = SimpleNamespace(generate_csv=AsyncMock())
+    drive_stub = SimpleNamespace(
+        update_defect_report_rows=AsyncMock(
+            return_value={
+                "fileId": "sheet-id",
+                "fileName": "defect-report.xlsx",
+                "modifiedTime": "2024-05-01T00:00:00Z",
+            }
+        )
+    )
+
+    app.dependency_overrides[get_ai_generation_service] = lambda: ai_stub
+    app.dependency_overrides[get_drive_service] = lambda: drive_stub
+
+    return app, ai_stub, drive_stub
+
+
+def test_finalize_defect_report_updates_spreadsheet_without_ai():
+    app, ai_stub, drive_stub = _create_app_with_mocks()
+
+    rows_payload = [
+        {
+            "order": "1",
+            "environment": "윈도우 11",
+            "summary": "로그인 오류",
+            "severity": "H",
+            "frequency": "A",
+            "quality": "신뢰성",
+            "description": "로그인 시 빈 화면이 표시됩니다.",
+            "vendorResponse": "대응 예정",
+            "fixStatus": "미해결",
+            "note": "스크린샷 참조",
+        },
+        {
+            "order": "2",
+            "environment": "macOS",
+            "summary": "버튼 표시 문제",
+            "severity": "M",
+            "frequency": "B",
+            "quality": "사용성",
+            "description": "설정 저장 버튼이 가려집니다.",
+            "vendorResponse": "확인 중",
+            "fixStatus": "미해결",
+            "note": "관련 로그 첨부",
+        },
+    ]
+    attachment_stubs = [
+        {"defect_index": 1, "fileName": "defect-01-login.png"},
+        {"defect_index": 2, "fileName": "defect-02-settings.png"},
+    ]
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/drive/projects/test-project/generate",
+            data={
+                "menu_id": "defect-report",
+                "rows": json.dumps(rows_payload, ensure_ascii=False),
+                "attachment_names": json.dumps(attachment_stubs, ensure_ascii=False),
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("status") == "updated"
+    assert payload.get("fileId") == "sheet-id"
+
+    ai_stub.generate_csv.assert_not_called()
+    assert drive_stub.update_defect_report_rows.await_count == 1
+
+    await_args = drive_stub.update_defect_report_rows.await_args
+    assert await_args.kwargs["project_id"] == "test-project"
+    assert await_args.kwargs["google_id"] is None
+    assert await_args.kwargs["images"] is None
+
+    expected_rows = defect_reports.normalize_defect_report_rows(rows_payload)
+    assert await_args.kwargs["rows"] == expected_rows
+    assert await_args.kwargs["attachment_notes"] == {
+        1: ["defect-01-login.png"],
+        2: ["defect-02-settings.png"],
+    }
+
+    assert payload.get("rows") == expected_rows
+    assert payload.get("headers") == list(defect_reports.DEFECT_REPORT_EXPECTED_HEADERS)

--- a/frontend/src/components/defect-report-workflow/__tests__/useDefectFinalize.test.ts
+++ b/frontend/src/components/defect-report-workflow/__tests__/useDefectFinalize.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useDefectFinalize, type DefectFinalizeRow } from '../hooks'
+
+function getFormDataEntries(body: FormData) {
+  return Array.from(body.entries()).map(([key, value]) => {
+    if (value instanceof File) {
+      return [key, { name: value.name, size: value.size }]
+    }
+    return [key, value]
+  })
+}
+
+describe('useDefectFinalize', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('submits rows and attachment stubs without summary file', async () => {
+    const responsePayload = { fileId: 'spreadsheet', fileName: 'defect.xlsx' }
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(responsePayload), {
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+        }) as Response,
+      )
+
+    const { result } = renderHook(() => useDefectFinalize({ backendUrl: '/api', projectId: 'p' }))
+
+    const rows: DefectFinalizeRow[] = [
+      {
+        order: '1',
+        environment: '윈도우 11',
+        summary: '요약',
+        severity: 'H',
+        frequency: 'A',
+        quality: '신뢰성',
+        description: '상세 설명',
+        vendorResponse: '대기',
+        fixStatus: '미해결',
+        note: '이미지 참조',
+      },
+    ]
+
+    const attachments = {
+      1: [new File(['image'], '첨부.png', { type: 'image/png' })],
+    }
+
+    await act(async () => {
+      const payload = await result.current.finalize(rows, attachments)
+      expect(payload).toEqual(responsePayload)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0]
+    const formData = options?.body as FormData
+    const entries = getFormDataEntries(formData)
+
+    expect(entries.some(([key]) => key === 'menu_id')).toBe(true)
+    expect(entries.some(([key]) => key === 'rows')).toBe(true)
+    expect(entries.some(([key]) => key === 'attachment_names')).toBe(true)
+    expect(entries.some(([key]) => key === 'files')).toBe(false)
+
+    const rowsEntry = entries.find(([key]) => key === 'rows')
+    expect(rowsEntry).toBeDefined()
+    const parsedRows = JSON.parse(rowsEntry?.[1] as string)
+    expect(parsedRows).toEqual([
+      {
+        order: '1',
+        environment: '윈도우 11',
+        summary: '요약',
+        severity: 'H',
+        frequency: 'A',
+        quality: '신뢰성',
+        description: '상세 설명',
+        vendorResponse: '대기',
+        fixStatus: '미해결',
+        note: '이미지 참조',
+      },
+    ])
+
+    const attachmentsEntry = entries.find(([key]) => key === 'attachment_names')
+    expect(attachmentsEntry).toBeDefined()
+    const parsedAttachments = JSON.parse(attachmentsEntry?.[1] as string)
+    expect(parsedAttachments).toEqual([
+      { defect_index: 1, fileName: 'defect-01-첨부.png' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- allow `/drive/projects/{project_id}/generate` defect-report requests with serialized rows and attachment names to bypass AI and update the spreadsheet directly
- cover the new finalize workflow with backend and frontend unit tests
- document the updated UI↔backend contract for defect report finalization

## Testing
- pytest backend/tests/test_drive_defect_finalize.py

------
https://chatgpt.com/codex/tasks/task_e_68fdda727c6c8330ba5645ce5e72d6c2