### PR TITLE
Fix defect report workflow parameter mismatches

### DIFF
--- a/frontend/src/components/defect-report-workflow/hooks.ts
+++ b/frontend/src/components/defect-report-workflow/hooks.ts
@@ -13,6 +13,7 @@ import {
 } from './types'
 import {
   buildAttachmentFileName,
+  buildFinalizeRowPayload,
   buildRowsFromJsonTable,
   createFileKey,
 } from './utils'
@@ -745,7 +746,7 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
       const formData = new FormData()
       formData.append('menu_id', 'defect-report')
 
-      const rowPayload = rows.map((row) => ({ index: row.index, cells: row.cells }))
+      const rowPayload = rows.map((row) => buildFinalizeRowPayload(row))
       const attachmentNameMap: Record<number, string[]> = {}
 
       const metadataEntries: Array<Record<string, unknown>> = []

--- a/frontend/src/components/defect-report-workflow/utils.ts
+++ b/frontend/src/components/defect-report-workflow/utils.ts
@@ -1,6 +1,11 @@
-import { DEFECT_REPORT_COLUMNS, DEFECT_REPORT_START_ROW, type DefectReportTableRow } from './types'
+import {
+  DEFECT_REPORT_COLUMNS,
+  DEFECT_REPORT_START_ROW,
+  type DefectReportTableRow,
+  type FinalizedDefectRow,
+} from './types'
 
-const DEFECT_COLUMN_TO_FIELD: Record<string, string> = {
+export const DEFECT_COLUMN_TO_FIELD: Record<string, string> = {
   순번: 'order',
   '시험환경(OS)': 'environment',
   결함요약: 'summary',
@@ -11,6 +16,19 @@ const DEFECT_COLUMN_TO_FIELD: Record<string, string> = {
   '업체 응답': 'vendorResponse',
   수정여부: 'fixStatus',
   비고: 'note',
+}
+
+const FINALIZE_FIELD_TO_COLUMN: Record<string, string> = {
+  order: '순번',
+  environment: '시험환경(OS)',
+  summary: '결함요약',
+  severity: '결함정도',
+  frequency: '발생빈도',
+  quality: '품질특성',
+  description: '결함 설명',
+  vendorResponse: '업체 응답',
+  fixStatus: '수정여부',
+  note: '비고',
 }
 
 function normalizeKey(key: unknown): string {
@@ -124,5 +142,28 @@ export function buildRowsFromJsonTable(
   })
 
   return tableRows
+}
+
+function normalizeFinalizeValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.trim()
+  }
+  if (value == null) {
+    return ''
+  }
+  return String(value).trim()
+}
+
+export function buildFinalizeRowPayload(row: FinalizedDefectRow): Record<string, string> {
+  const payload: Record<string, string> = {}
+  Object.entries(FINALIZE_FIELD_TO_COLUMN).forEach(([field, column]) => {
+    payload[field] = normalizeFinalizeValue(row.cells[column])
+  })
+
+  if (!payload.order) {
+    payload.order = normalizeFinalizeValue(row.cells['순번']) || String(row.index)
+  }
+
+  return payload
 }
 


### PR DESCRIPTION
## Summary
- add explicit rows_json and attachment_names_json form parameters for the defect report generation endpoint
- align the finalize flow to send normalized defect rows instead of nested cell maps
- share finalized row normalization utilities for consistent payload construction

## Testing
- npm test -- --runTestsByPath src/components/defect-report-workflow/__tests__/DefectTable.test.tsx *(fails: vitest not installed without npm install)*
- npm install *(fails: registry access is forbidden in this environment)*
- pip install -r backend/requirements.txt *(fails: proxy blocks xlrd download)*

------
https://chatgpt.com/codex/tasks/task_e_68fde0d36a888330a532d83f3fe4594e