### PR TITLE
Allow additional configuration image uploads in feature list workflow

### DIFF
--- a/frontend/src/components/file-uploader/useFileUploader.ts
+++ b/frontend/src/components/file-uploader/useFileUploader.ts
@@ -102,9 +102,6 @@ export function useFileUploader({
   }, [maxFiles])
 
   const atCapacity = maxFileCount !== undefined && files.length >= maxFileCount
-  const shouldHideForFilled =
-    hideDropzoneWhenFilled && (maxFileCount !== undefined ? files.length >= maxFileCount : files.length > 0)
-  const dropzoneDisabled = disabled || atCapacity || shouldHideForFilled
   const isGridVariant = variant === 'grid'
 
   const acceptValue = useMemo(() => {
@@ -120,6 +117,11 @@ export function useFileUploader({
   }, [files, multiple])
 
   const shouldRenderCompactPreview = shouldUseCompactLayout && hideDropzoneWhenFilled
+  const shouldHideForFilled =
+    hideDropzoneWhenFilled &&
+    !shouldRenderCompactPreview &&
+    (maxFileCount !== undefined ? files.length >= maxFileCount : files.length > 0)
+  const dropzoneDisabled = disabled || atCapacity || shouldHideForFilled
   const shouldShowDropzone =
     !hideDropzoneWhenFilled || files.length === 0 || shouldRenderCompactPreview
 


### PR DESCRIPTION
## Summary
- keep the file uploader dropzone interactive when multiple image uploads are allowed and compact preview is shown
- only disable the dropzone once capacity is reached so configuration images can be added sequentially

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68fde522fca883309efde5c11e2ae807