### PR TITLE
Add Google Drive project deletion support

### DIFF
--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -533,6 +533,17 @@ async def create_drive_project(
     )
 
 
+@router.delete("/drive/projects/{project_id}")
+async def delete_drive_project(
+    project_id: str,
+    google_id: Optional[str] = Query(
+        None, description="Drive 작업에 사용할 Google 사용자 식별자 (sub)"
+    ),
+    drive_service: GoogleDriveService = Depends(get_drive_service),
+) -> Dict[str, Any]:
+    return await drive_service.delete_project(project_id=project_id, google_id=google_id)
+
+
 @router.post("/drive/projects/{project_id}/defect-report/formalize")
 async def formalize_defect_report(
     project_id: str,

--- a/backend/app/services/google_drive/client.py
+++ b/backend/app/services/google_drive/client.py
@@ -542,6 +542,23 @@ class GoogleDriveClient:
 
         raise HTTPException(status_code=401, detail="Google Drive 인증이 만료되었습니다. 다시 로그인해주세요.")
 
+    async def delete_file(
+        self,
+        tokens: StoredTokens,
+        *,
+        file_id: str,
+    ) -> StoredTokens:
+        params = {
+            "supportsAllDrives": "true",
+        }
+        _, updated_tokens = await self.drive_request(
+            tokens,
+            method="DELETE",
+            path=f"{DRIVE_FILES_ENDPOINT}/{file_id}",
+            params=params,
+        )
+        return updated_tokens
+
     async def find_file_by_name(
         self,
         tokens: StoredTokens,


### PR DESCRIPTION
## Summary
- add an API endpoint to delete Google Drive projects
- implement Google Drive client and service helpers to remove folders safely
- cover project deletion scenarios with integration tests

## Testing
- pytest backend/tests/test_google_drive_service_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ff5a0a7f148330bb28d771b2340741