### PR TITLE
Add configuration image capture workflow

### DIFF
--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .config import Settings, load_settings
 from .services.ai_generation import AIGenerationService
+from .services.configuration_images import ConfigurationImageService
 from .services.prompt_config import PromptConfigService
 from .services.prompt_request_log import PromptRequestLogService
 from .services.google_drive import GoogleDriveService
@@ -36,6 +37,7 @@ class Container:
             prompt_request_log_service=self._prompt_request_log_service,
             openai_client=openai_client,
         )
+        self._configuration_image_service = ConfigurationImageService(self._drive_service)
 
     @property
     def settings(self) -> Settings:
@@ -68,3 +70,7 @@ class Container:
     @property
     def security_report_service(self) -> SecurityReportService:
         return self._security_report_service
+
+    @property
+    def configuration_image_service(self) -> ConfigurationImageService:
+        return self._configuration_image_service

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -4,6 +4,7 @@ from fastapi import Depends, Request
 
 from .container import Container
 from .services.ai_generation import AIGenerationService
+from .services.configuration_images import ConfigurationImageService
 from .services.google_drive import GoogleDriveService
 from .services.prompt_config import PromptConfigService
 from .services.prompt_request_log import PromptRequestLogService
@@ -53,3 +54,9 @@ def get_security_report_service(
     container: Container = Depends(get_container),
 ) -> SecurityReportService:
     return container.security_report_service
+
+
+def get_configuration_image_service(
+    container: Container = Depends(get_container),
+) -> ConfigurationImageService:
+    return container.configuration_image_service

--- a/backend/app/services/configuration_images/__init__.py
+++ b/backend/app/services/configuration_images/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for extracting and managing configuration images."""
+
+from .service import ConfigurationImageService
+
+__all__ = ["ConfigurationImageService"]

--- a/backend/app/services/configuration_images/capture.py
+++ b/backend/app/services/configuration_images/capture.py
@@ -1,0 +1,374 @@
+"""Video capture utilities for extracting configuration images.
+
+This module implements the sensitive scene-change detection algorithm described
+in the specification. The implementation keeps the original Python script's
+behaviour while exposing a clean function API that can be reused from the
+web application.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import cv2
+import numpy as np
+from skimage.metrics import structural_similarity as ssim
+
+
+TARGET_FPS = 10.0
+LONG_SIDE = 1080
+GRID_COLS = 32
+GRID_ROWS = 32
+SSIM_FULL_THRESHOLD = 0.95
+BLOCK_THRESHOLD = 0.90
+BLOCK_TRIGGER_COUNT = 3
+EDGE_DIFF_PERCENT = 0.05
+PERSIST_FRAMES = 2
+MIN_GAP_SECONDS = 1.0
+CURSOR_MIN = 8
+CURSOR_MAX = 80
+CURSOR_DILATE = 28
+COVER_SKIP_RATIO = 0.5
+
+
+@dataclass(slots=True)
+class CaptureEvent:
+    """Represents a row in the capture event log."""
+
+    time_sec: float
+    ssim_full: float | None
+    min_block_ssim: float | None
+    low_blocks: int | None
+    edge_ratio: float | None
+    phash_distance: int | None
+    note: str
+    filename: str
+
+
+@dataclass(slots=True)
+class CapturedImage:
+    """Represents a saved image from the capture process."""
+
+    path: Path
+    filename: str
+    time_sec: float
+    is_start: bool
+
+
+@dataclass(slots=True)
+class CaptureResult:
+    """Return value for the capture routine."""
+
+    images: List[CapturedImage]
+    events_csv: str
+
+
+def _to_gray_small(frame: np.ndarray, *, long_side: int) -> tuple[np.ndarray, np.ndarray]:
+    height, width = frame.shape[:2]
+    scale = float(long_side) / float(max(height, width))
+    if scale < 1.0:
+        resized = cv2.resize(frame, (int(width * scale), int(height * scale)), interpolation=cv2.INTER_AREA)
+    else:
+        resized = frame
+    gray = cv2.cvtColor(resized, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (3, 3), 0)
+    return blurred, resized
+
+
+def _make_cursor_mask(
+    prev_gray: np.ndarray,
+    gray: np.ndarray,
+    *,
+    min_size: int,
+    max_size: int,
+    dilate_px: int,
+) -> np.ndarray:
+    mask = np.ones_like(gray, dtype=np.uint8)
+    diff = cv2.absdiff(prev_gray, gray)
+
+    thr0, _ = cv2.threshold(diff, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    threshold = max(15, int(thr0 * 0.6))
+    binary = cv2.threshold(diff, threshold, 255, cv2.THRESH_BINARY)[1]
+
+    opened = cv2.morphologyEx(binary, cv2.MORPH_OPEN, np.ones((3, 3), np.uint8))
+    closed = cv2.morphologyEx(opened, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
+
+    contours, _ = cv2.findContours(closed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    cursor_regions: List[tuple[int, int, int, int]] = []
+    for contour in contours:
+        x, y, width, height = cv2.boundingRect(contour)
+        if width < min_size or height < min_size or width > max_size or height > max_size:
+            continue
+        aspect_ratio = width / float(height)
+        if aspect_ratio < 0.4 or aspect_ratio > 2.5:
+            continue
+        cursor_regions.append((x, y, width, height))
+
+    if cursor_regions:
+        cursor_mask = np.zeros_like(mask, dtype=np.uint8)
+        for x, y, width, height in cursor_regions:
+            cv2.rectangle(cursor_mask, (x, y), (x + width, y + height), 1, -1)
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (dilate_px, dilate_px))
+        dilated = cv2.dilate(cursor_mask, kernel)
+        mask = (mask & (1 - dilated)).astype(np.uint8)
+
+    return mask
+
+
+def _ssim_with_mask(prev_gray: np.ndarray, gray: np.ndarray, mask: np.ndarray) -> float:
+    score, s_map = ssim(prev_gray, gray, data_range=255, full=True)
+    valid = mask == 1
+    if np.count_nonzero(valid) < 100:
+        return float(score)
+    return float(s_map[valid].mean())
+
+
+def _block_ssim_with_mask(
+    prev_gray: np.ndarray,
+    gray: np.ndarray,
+    mask: np.ndarray,
+    *,
+    grid_cols: int,
+    grid_rows: int,
+    block_threshold: float,
+    cover_skip: float,
+) -> tuple[float, int]:
+    height, width = gray.shape[:2]
+    block_width, block_height = width // grid_cols, height // grid_rows
+    low_count = 0
+    min_block_ssim = 1.0
+
+    for row in range(grid_rows):
+        for col in range(grid_cols):
+            x0, y0 = col * block_width, row * block_height
+            x1, y1 = x0 + block_width, y0 + block_height
+            if block_width < 6 or block_height < 6:
+                continue
+            sub_mask = mask[y0:y1, x0:x1]
+            if np.mean(sub_mask == 0) > cover_skip:
+                continue
+            score = ssim(prev_gray[y0:y1, x0:x1], gray[y0:y1, x0:x1], data_range=255)
+            min_block_ssim = min(min_block_ssim, float(score))
+            if score < block_threshold:
+                low_count += 1
+
+    return float(min_block_ssim), low_count
+
+
+def _edge_change_ratio(prev_gray: np.ndarray, gray: np.ndarray, mask: np.ndarray) -> float:
+    edges_prev = cv2.Canny(prev_gray, 60, 120) * mask
+    edges_cur = cv2.Canny(gray, 60, 120) * mask
+    count_prev = int(np.count_nonzero(edges_prev))
+    count_cur = int(np.count_nonzero(edges_cur))
+    if count_prev == 0:
+        return 1.0 if count_cur > 0 else 0.0
+    return (count_cur - count_prev) / float(count_prev)
+
+
+def _phash(gray: np.ndarray, hash_size: int = 8, highfreq_factor: int = 4) -> np.ndarray:
+    resized = cv2.resize(
+        gray,
+        (hash_size * highfreq_factor, hash_size * highfreq_factor),
+        interpolation=cv2.INTER_AREA,
+    ).astype(np.float32)
+    dct = cv2.dct(resized)
+    dct_low = dct[:hash_size, :hash_size]
+    median = np.median(dct_low[1:, 1:])
+    return (dct_low > median).flatten()
+
+
+def _hamming(a: np.ndarray, b: np.ndarray) -> int:
+    return int(np.count_nonzero(a != b))
+
+
+def _format_filename(prefix: str, suffix: str = "") -> str:
+    sanitized = prefix.strip()
+    if not sanitized:
+        sanitized = "0"
+    return f"{sanitized}{suffix}.png"
+
+
+def capture_video_changes(source_path: Path, output_dir: Path) -> CaptureResult:
+    """Extract scene changes from *source_path* into *output_dir*.
+
+    Parameters
+    ----------
+    source_path:
+        Path to the input video file.
+    output_dir:
+        Directory where PNG captures should be written.
+
+    Returns
+    -------
+    CaptureResult
+        Contains information about saved images and the CSV event log.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    capture = cv2.VideoCapture(str(source_path))
+    if not capture.isOpened():
+        raise RuntimeError(f"동영상을 열 수 없습니다: {source_path}")
+
+    src_fps = capture.get(cv2.CAP_PROP_FPS)
+    if not src_fps or math.isclose(src_fps, 0.0):
+        src_fps = 30.0
+    step = max(1, int(round(src_fps / TARGET_FPS)))
+
+    events: List[CaptureEvent] = []
+    images: List[CapturedImage] = []
+
+    last_gray: np.ndarray | None = None
+    last_hash: np.ndarray | None = None
+    pending = 0
+    last_capture_time = -1e9
+    frame_index = 0
+
+    try:
+        while True:
+            ok, frame = capture.read()
+            if not ok:
+                break
+
+            if frame_index % step != 0:
+                frame_index += 1
+                continue
+
+            timestamp = capture.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+            gray_small, _ = _to_gray_small(frame, long_side=LONG_SIDE)
+
+            if last_gray is None:
+                filename = _format_filename(f"{int(timestamp * 1000):012d}", suffix="_start")
+                file_path = output_dir / filename
+                if not cv2.imwrite(str(file_path), frame):
+                    raise RuntimeError(f"이미지를 저장하지 못했습니다: {file_path}")
+                events.append(
+                    CaptureEvent(
+                        time_sec=timestamp,
+                        ssim_full=None,
+                        min_block_ssim=None,
+                        low_blocks=None,
+                        edge_ratio=None,
+                        phash_distance=None,
+                        note="start",
+                        filename=filename,
+                    )
+                )
+                images.append(
+                    CapturedImage(path=file_path, filename=filename, time_sec=timestamp, is_start=True)
+                )
+                last_gray = gray_small
+                last_hash = _phash(gray_small)
+                frame_index += 1
+                continue
+
+            mask = _make_cursor_mask(
+                last_gray,
+                gray_small,
+                min_size=CURSOR_MIN,
+                max_size=CURSOR_MAX,
+                dilate_px=CURSOR_DILATE,
+            )
+
+            ssim_full = _ssim_with_mask(last_gray, gray_small, mask)
+            block_min, block_low = _block_ssim_with_mask(
+                last_gray,
+                gray_small,
+                mask,
+                grid_cols=GRID_COLS,
+                grid_rows=GRID_ROWS,
+                block_threshold=BLOCK_THRESHOLD,
+                cover_skip=COVER_SKIP_RATIO,
+            )
+            edge_ratio = _edge_change_ratio(last_gray, gray_small, mask)
+
+            current_hash = _phash(gray_small)
+            phash_distance = _hamming(last_hash, current_hash) if last_hash is not None else 0
+
+            changed = (
+                ssim_full < SSIM_FULL_THRESHOLD
+                or block_low >= BLOCK_TRIGGER_COUNT
+                or edge_ratio >= EDGE_DIFF_PERCENT
+            )
+
+            if changed:
+                pending += 1
+            else:
+                pending = 0
+
+            should_capture = pending >= PERSIST_FRAMES and (timestamp - last_capture_time) >= MIN_GAP_SECONDS
+            if should_capture:
+                filename = _format_filename(f"{int(timestamp * 1000):012d}")
+                file_path = output_dir / filename
+                if not cv2.imwrite(str(file_path), frame):
+                    raise RuntimeError(f"이미지를 저장하지 못했습니다: {file_path}")
+                events.append(
+                    CaptureEvent(
+                        time_sec=timestamp,
+                        ssim_full=ssim_full,
+                        min_block_ssim=block_min,
+                        low_blocks=block_low,
+                        edge_ratio=edge_ratio,
+                        phash_distance=phash_distance,
+                        note="captured",
+                        filename=filename,
+                    )
+                )
+                images.append(
+                    CapturedImage(path=file_path, filename=filename, time_sec=timestamp, is_start=False)
+                )
+                last_capture_time = timestamp
+                last_gray = gray_small
+                last_hash = current_hash
+                pending = 0
+
+            frame_index += 1
+    finally:
+        capture.release()
+
+    if not images:
+        raise RuntimeError("장면 전환을 감지하지 못했습니다. 동영상 내용을 확인해 주세요.")
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        [
+            "time_sec",
+            "ssim_full",
+            "min_block_ssim",
+            "low_blocks",
+            "edge_ratio",
+            "phash_dist",
+            "note",
+            "filename",
+        ]
+    )
+    for event in events:
+        writer.writerow(
+            [
+                f"{event.time_sec:.3f}",
+                "" if event.ssim_full is None else f"{event.ssim_full:.4f}",
+                "" if event.min_block_ssim is None else f"{event.min_block_ssim:.4f}",
+                "" if event.low_blocks is None else event.low_blocks,
+                "" if event.edge_ratio is None else f"{event.edge_ratio:.4f}",
+                "" if event.phash_distance is None else event.phash_distance,
+                event.note,
+                event.filename,
+            ]
+        )
+
+    return CaptureResult(images=images, events_csv=buffer.getvalue())
+
+
+__all__ = [
+    "CaptureEvent",
+    "CapturedImage",
+    "CaptureResult",
+    "capture_video_changes",
+]

--- a/backend/app/services/configuration_images/service.py
+++ b/backend/app/services/configuration_images/service.py
@@ -1,0 +1,148 @@
+"""High level service for handling configuration image captures."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from fastapi import HTTPException, UploadFile
+
+from ..google_drive.service import GoogleDriveService
+from .capture import capture_video_changes
+
+
+@dataclass(slots=True)
+class _UploadCandidate:
+    name: str
+    content: bytes
+    mime_type: str
+    time_sec: float
+    is_start: bool
+
+
+class ConfigurationImageService:
+    """Coordinates video capture processing and Google Drive uploads."""
+
+    EVENTS_FILENAME_TEMPLATE = "형상 이미지 이벤트_{timestamp}.csv"
+
+    def __init__(self, drive_service: GoogleDriveService) -> None:
+        self._drive_service = drive_service
+
+    async def capture_and_upload(
+        self,
+        *,
+        project_id: str,
+        upload: UploadFile,
+        google_id: Optional[str],
+    ) -> Dict[str, Any]:
+        filename = upload.filename or "configuration-video.mp4"
+        suffix = Path(filename).suffix or ".mp4"
+
+        data = await upload.read()
+        if not data:
+            raise HTTPException(status_code=422, detail="업로드된 동영상이 비어 있습니다.")
+
+        candidates, events_csv = await self._process_video_bytes(data, suffix)
+
+        if not candidates:
+            raise HTTPException(
+                status_code=500,
+                detail="형상 이미지를 추출하지 못했습니다. 동영상 파일을 다시 확인해 주세요.",
+            )
+
+        events_filename = self.EVENTS_FILENAME_TEMPLATE.format(
+            timestamp=dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
+        )
+        events_bytes = events_csv.encode("utf-8")
+
+        upload_result = await self._drive_service.upload_configuration_captures(
+            project_id=project_id,
+            google_id=google_id,
+            images=[
+                {
+                    "name": candidate.name,
+                    "content": candidate.content,
+                    "contentType": candidate.mime_type,
+                    "timeSec": candidate.time_sec,
+                    "isStart": candidate.is_start,
+                }
+                for candidate in candidates
+            ],
+            events_file={
+                "name": events_filename,
+                "content": events_bytes,
+                "contentType": "text/csv",
+            },
+        )
+
+        return upload_result
+
+    async def list_images(
+        self,
+        *,
+        project_id: str,
+        google_id: Optional[str],
+    ) -> Dict[str, Any]:
+        return await self._drive_service.list_configuration_images(
+            project_id=project_id,
+            google_id=google_id,
+        )
+
+    async def delete_images(
+        self,
+        *,
+        project_id: str,
+        google_id: Optional[str],
+        file_ids: Sequence[str],
+    ) -> int:
+        return await self._drive_service.delete_configuration_images(
+            project_id=project_id,
+            google_id=google_id,
+            file_ids=file_ids,
+        )
+
+    async def download_file(
+        self,
+        *,
+        project_id: str,
+        google_id: Optional[str],
+        file_id: str,
+    ) -> Dict[str, Any]:
+        return await self._drive_service.download_configuration_file(
+            project_id=project_id,
+            google_id=google_id,
+            file_id=file_id,
+        )
+
+    async def _process_video_bytes(self, data: bytes, suffix: str) -> Tuple[Sequence[_UploadCandidate], str]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._process_sync, data, suffix)
+
+    def _process_sync(self, data: bytes, suffix: str) -> Tuple[Sequence[_UploadCandidate], str]:
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmpdir:
+            temp_dir = Path(tmpdir)
+            video_path = temp_dir / f"input{suffix}"
+            video_path.write_bytes(data)
+            capture_dir = temp_dir / "captures"
+            result = capture_video_changes(video_path, capture_dir)
+
+            candidates = [
+                _UploadCandidate(
+                    name=image.filename,
+                    content=(capture_dir / image.filename).read_bytes(),
+                    mime_type="image/png",
+                    time_sec=image.time_sec,
+                    is_start=image.is_start,
+                )
+                for image in result.images
+            ]
+
+            return candidates, result.events_csv
+
+
+__all__ = ["ConfigurationImageService"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,9 +11,12 @@ httptools==0.6.4
 httpx==0.28.1
 idna==3.10
 jiter==0.11.0
+numpy==2.2.2
 openai==1.108.1
 pandas==2.2.3
 openpyxl==3.1.5
+opencv-python-headless==4.10.0.84
+scikit-image==0.24.0
 xlrd==2.0.1
 pydantic==2.11.9
 pydantic_core==2.33.2

--- a/frontend/src/app/routing/resolvePage.tsx
+++ b/frontend/src/app/routing/resolvePage.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import type { AuthStatus } from '../../auth'
 import { DriveSetupPage } from '../../pages/DriveSetupPage'
 import { LoginPage } from '../../pages/LoginPage'
+import { ConfigurationImageEditPage } from '../../pages/ConfigurationImageEditPage'
 import { FeatureListEditPage } from '../../pages/FeatureListEditPage'
 import { ProjectManagementPage } from '../../pages/ProjectManagementPage'
 import { TestcaseEditPage } from '../../pages/TestcaseEditPage'
@@ -10,6 +11,7 @@ import { DefectReportEditPage } from '../../pages/DefectReportEditPage'
 import { AdminPromptsPage } from '../../pages/AdminPromptsPage'
 
 const PROJECT_PATH_PATTERN = /^\/projects\/([^/]+)$/
+const CONFIG_IMAGES_EDIT_PATTERN = /^\/projects\/([^/]+)\/configuration-images\/edit$/
 const FEATURE_LIST_EDIT_PATTERN = /^\/projects\/([^/]+)\/feature-list\/edit$/
 const TESTCASE_EDIT_PATTERN = /^\/projects\/([^/]+)\/testcases\/edit$/
 const DEFECT_REPORT_EDIT_PATTERN = /^\/projects\/([^/]+)\/defect-report\/edit$/
@@ -33,6 +35,13 @@ export function resolvePage({ pathname, authStatus }: ResolvePageOptions): React
 
   if (pathname === ADMIN_PROMPTS_PATH) {
     return <AdminPromptsPage />
+  }
+
+  const configImageMatch = pathname.match(CONFIG_IMAGES_EDIT_PATTERN)
+  if (configImageMatch) {
+    return (
+      <ConfigurationImageEditPage projectId={decodeURIComponent(configImageMatch[1])} />
+    )
   }
 
   const featureListMatch = pathname.match(FEATURE_LIST_EDIT_PATTERN)

--- a/frontend/src/components/fileUploaderTypes.ts
+++ b/frontend/src/components/fileUploaderTypes.ts
@@ -8,6 +8,8 @@ export type FileType =
   | 'png'
   | 'csv'
   | 'html'
+  | 'mp4'
+  | 'mov'
 
 interface FileTypeInfo {
   label: string
@@ -66,6 +68,16 @@ export const FILE_TYPE_OPTIONS: Record<FileType, FileTypeInfo> = {
     label: 'HTML',
     accept: ['.html', '.htm', 'text/html'],
     extensions: ['html', 'htm'],
+  },
+  mp4: {
+    label: 'MP4',
+    accept: ['.mp4', 'video/mp4'],
+    extensions: ['mp4'],
+  },
+  mov: {
+    label: 'MOV',
+    accept: ['.mov', 'video/quicktime'],
+    extensions: ['mov'],
   },
 }
 

--- a/frontend/src/pages/ConfigurationImageEditPage.css
+++ b/frontend/src/pages/ConfigurationImageEditPage.css
@@ -1,0 +1,267 @@
+.configuration-images {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: #1f2933;
+}
+
+.configuration-images__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.configuration-images__back {
+  align-self: flex-start;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #cbd2d9;
+  border-radius: 0.5rem;
+  background: #f5f7fa;
+  color: #1f2933;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.configuration-images__back:hover,
+.configuration-images__back:focus {
+  background: #e4e7eb;
+  outline: none;
+}
+
+.configuration-images__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #102a43;
+}
+
+.configuration-images__description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #52606d;
+}
+
+.configuration-images__highlight-note {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: #f0f4ff;
+  color: #243b53;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.configuration-images__folder {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #829ab1;
+}
+
+.configuration-images__alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #fee2e2;
+  color: #7f1d1d;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.configuration-images__retry {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #991b1b;
+  background: transparent;
+  border-radius: 0.5rem;
+  color: #991b1b;
+  cursor: pointer;
+}
+
+.configuration-images__success {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.configuration-images__loading,
+.configuration-images__empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #52606d;
+  border: 1px dashed #d2d6dc;
+  border-radius: 0.75rem;
+}
+
+.configuration-images__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.configuration-images__action-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.configuration-images__action-group button {
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd2d9;
+  background: #f5f7fa;
+  color: #1f2933;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.configuration-images__action-group button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.configuration-images__action-group button:not(:disabled):hover {
+  background: #e4e7eb;
+}
+
+.configuration-images__delete {
+  border-color: #d64545;
+  color: #d64545;
+  background: #fff5f5;
+}
+
+.configuration-images__delete:not(:disabled):hover {
+  background: #fde8e8;
+}
+
+.configuration-images__events {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #52606d;
+}
+
+.configuration-images__events a {
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.configuration-images__events a:hover,
+.configuration-images__events a:focus {
+  text-decoration: underline;
+}
+
+.configuration-images__events-time {
+  color: #9aa5b1;
+}
+
+.configuration-images__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.configuration-images__card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #d2d6dc;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.configuration-images__card--selected {
+  border-color: #2f855a;
+  box-shadow: 0 0 0 2px rgba(47, 133, 90, 0.15);
+}
+
+.configuration-images__card--recent {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.configuration-images__thumb {
+  aspect-ratio: 16 / 9;
+  background: #f0f4f8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.configuration-images__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.configuration-images__info {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.configuration-images__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #243b53;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.configuration-images__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #7b8794;
+}
+
+.configuration-images__badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.configuration-images__select {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #334e68;
+}
+
+.configuration-images__select input {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 640px) {
+  .configuration-images {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .configuration-images__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .configuration-images__action-group {
+    justify-content: space-between;
+  }
+}

--- a/frontend/src/pages/ConfigurationImageEditPage.tsx
+++ b/frontend/src/pages/ConfigurationImageEditPage.tsx
@@ -1,0 +1,396 @@
+import './ConfigurationImageEditPage.css'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { getBackendUrl } from '../config'
+import { navigate } from '../navigation'
+
+type LoadState = 'idle' | 'loading' | 'error' | 'ready'
+
+type ConfigurationImageEntry = {
+  id: string
+  name: string
+  mimeType?: string
+  timeSec?: number
+  isStart?: boolean
+  modifiedTime?: string
+}
+
+type ConfigurationEventsEntry = {
+  id: string
+  name: string
+  mimeType?: string
+  modifiedTime?: string
+} | null
+
+type ConfigurationImageListResponse = {
+  folderId?: string
+  files?: ConfigurationImageEntry[]
+  eventsFile?: ConfigurationEventsEntry
+}
+
+interface ConfigurationImageEditPageProps {
+  projectId: string
+}
+
+function formatTimestamp(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  try {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) {
+      return null
+    }
+    return new Intl.DateTimeFormat('ko-KR', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date)
+  } catch {
+    return null
+  }
+}
+
+function formatTimecode(seconds?: number): string | null {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) {
+    return null
+  }
+  if (seconds < 0) {
+    return null
+  }
+  const total = Math.round(seconds)
+  const minutes = Math.floor(total / 60)
+  const remaining = total % 60
+  return `${minutes}:${remaining.toString().padStart(2, '0')}`
+}
+
+function parseRecentIds(): Set<string> {
+  if (typeof window === 'undefined') {
+    return new Set()
+  }
+  const params = new URLSearchParams(window.location.search)
+  const raw = params.get('recent')
+  if (!raw) {
+    return new Set()
+  }
+  const ids = raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  return new Set(ids)
+}
+
+export function ConfigurationImageEditPage({ projectId }: ConfigurationImageEditPageProps) {
+  const backendUrl = useMemo(() => getBackendUrl(), [])
+  const [images, setImages] = useState<ConfigurationImageEntry[]>([])
+  const [eventsFile, setEventsFile] = useState<ConfigurationEventsEntry>(null)
+  const [folderId, setFolderId] = useState<string | null>(null)
+  const [loadState, setLoadState] = useState<LoadState>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [reloadToken, setReloadToken] = useState(0)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const recentIds = useMemo(() => parseRecentIds(), [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoadState('loading')
+    setErrorMessage(null)
+
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          `${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/configuration-images`,
+          { signal: controller.signal },
+        )
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null)
+          const detail =
+            payload && typeof payload.detail === 'string'
+              ? payload.detail
+              : '형상 이미지를 불러오는 중 오류가 발생했습니다.'
+          throw new Error(detail)
+        }
+
+        const payload = (await response.json()) as ConfigurationImageListResponse
+        if (controller.signal.aborted) {
+          return
+        }
+
+        const nextImages = Array.isArray(payload.files)
+          ? payload.files.filter(
+              (item): item is ConfigurationImageEntry =>
+                typeof item?.id === 'string' && typeof item?.name === 'string',
+            )
+          : []
+
+        setImages(nextImages)
+        setEventsFile(
+          payload.eventsFile && typeof payload.eventsFile === 'object'
+            ? payload.eventsFile
+            : null,
+        )
+        setFolderId(typeof payload.folderId === 'string' ? payload.folderId : null)
+        setSelectedIds((prev) => {
+          if (prev.size === 0) {
+            return prev
+          }
+          const available = new Set(nextImages.map((item) => item.id))
+          const retained = new Set<string>()
+          prev.forEach((id) => {
+            if (available.has(id)) {
+              retained.add(id)
+            }
+          })
+          return retained
+        })
+        setLoadState('ready')
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return
+        }
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : '형상 이미지를 불러오는 중 예기치 않은 오류가 발생했습니다.'
+        setErrorMessage(message)
+        setLoadState('error')
+      }
+    }
+
+    fetchData()
+
+    return () => {
+      controller.abort()
+    }
+  }, [backendUrl, projectId, reloadToken])
+
+  const handleRetry = useCallback(() => {
+    setReloadToken((token) => token + 1)
+  }, [])
+
+  const handleBack = useCallback(() => {
+    const params = new URLSearchParams(window.location.search)
+    params.delete('recent')
+    params.delete('folderId')
+    const query = params.toString()
+    navigate(`/projects/${encodeURIComponent(projectId)}${query ? `?${query}` : ''}`)
+  }, [projectId])
+
+  const handleToggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedIds(new Set(images.map((item) => item.id)))
+  }, [images])
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const handleDeleteSelected = useCallback(async () => {
+    if (selectedIds.size === 0 || isDeleting) {
+      return
+    }
+
+    setIsDeleting(true)
+    setSuccessMessage(null)
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(
+        `${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/configuration-images`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ fileIds: Array.from(selectedIds) }),
+        },
+      )
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        const detail =
+          payload && typeof payload.detail === 'string'
+            ? payload.detail
+            : '선택한 이미지를 삭제하지 못했습니다.'
+        throw new Error(detail)
+      }
+
+      const payload = (await response.json().catch(() => null)) as
+        | { removed?: number }
+        | null
+      const removedCount =
+        payload && typeof payload.removed === 'number'
+          ? payload.removed
+          : selectedIds.size
+
+      setSuccessMessage(`선택한 ${removedCount}개의 이미지를 삭제했습니다.`)
+      setSelectedIds(new Set())
+      setReloadToken((token) => token + 1)
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : '선택한 이미지를 삭제하는 중 예기치 않은 오류가 발생했습니다.'
+      setErrorMessage(message)
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [backendUrl, isDeleting, projectId, selectedIds])
+
+  const isReady = loadState === 'ready'
+  const hasSelection = selectedIds.size > 0
+
+  return (
+    <div className="configuration-images">
+      <header className="configuration-images__header">
+        <button type="button" className="configuration-images__back" onClick={handleBack}>
+          프로젝트로 돌아가기
+        </button>
+        <h1 className="configuration-images__title">형상 이미지 검토</h1>
+        <p className="configuration-images__description">
+          시연 동영상에서 추출된 화면 이미지를 검토하고 필요 없는 장면을 제거하세요.
+          {recentIds.size > 0 && (
+            <span className="configuration-images__highlight-note">
+              최근 추가된 {recentIds.size}개의 이미지가 강조 표시됩니다.
+            </span>
+          )}
+        </p>
+        {folderId && (
+          <p className="configuration-images__folder">드라이브 폴더 ID: {folderId}</p>
+        )}
+      </header>
+
+      {errorMessage && (
+        <div className="configuration-images__alert" role="alert">
+          <p>{errorMessage}</p>
+          {loadState === 'error' && (
+            <button type="button" onClick={handleRetry} className="configuration-images__retry">
+              다시 시도
+            </button>
+          )}
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="configuration-images__success" role="status">
+          {successMessage}
+        </div>
+      )}
+
+      {loadState === 'loading' && (
+        <div className="configuration-images__loading">형상 이미지를 불러오는 중…</div>
+      )}
+
+      {isReady && (
+        <>
+          <div className="configuration-images__actions">
+            <div className="configuration-images__action-group">
+              <button type="button" onClick={handleSelectAll} disabled={images.length === 0}>
+                전체 선택
+              </button>
+              <button type="button" onClick={handleClearSelection} disabled={!hasSelection}>
+                선택 해제
+              </button>
+            </div>
+            <div className="configuration-images__action-group">
+              <button
+                type="button"
+                className="configuration-images__delete"
+                onClick={handleDeleteSelected}
+                disabled={!hasSelection || isDeleting}
+              >
+                선택한 이미지 삭제
+              </button>
+              <button type="button" onClick={handleRetry} disabled={isDeleting}>
+                새로 고침
+              </button>
+            </div>
+          </div>
+
+          {eventsFile && (
+            <div className="configuration-images__events">
+              <span>장면 변화 로그:</span>
+              <a
+                href={`${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/configuration-images/${encodeURIComponent(eventsFile.id)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {eventsFile.name || 'events.csv'}
+              </a>
+              {eventsFile.modifiedTime && (
+                <span className="configuration-images__events-time">
+                  {formatTimestamp(eventsFile.modifiedTime) ?? ''}
+                </span>
+              )}
+            </div>
+          )}
+
+          {images.length === 0 ? (
+            <p className="configuration-images__empty">표시할 형상 이미지가 없습니다.</p>
+          ) : (
+            <div className="configuration-images__grid">
+              {images.map((image) => {
+                const isSelected = selectedIds.has(image.id)
+                const isRecent = recentIds.has(image.id)
+                const timecode = formatTimecode(image.timeSec)
+                const timestampLabel = formatTimestamp(image.modifiedTime)
+
+                const classes = [
+                  'configuration-images__card',
+                  isSelected ? 'configuration-images__card--selected' : '',
+                  isRecent ? 'configuration-images__card--recent' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+
+                return (
+                  <div key={image.id} className={classes}>
+                    <div className="configuration-images__thumb">
+                      <img
+                        src={`${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/configuration-images/${encodeURIComponent(image.id)}`}
+                        alt={`${image.name} 미리보기`}
+                      />
+                    </div>
+                    <div className="configuration-images__info">
+                      <div className="configuration-images__name" title={image.name}>
+                        {image.name}
+                      </div>
+                      <div className="configuration-images__meta">
+                        {timecode && <span>장면 시각: {timecode}</span>}
+                        {image.isStart && <span className="configuration-images__badge">시작 화면</span>}
+                        {timestampLabel && <span>{timestampLabel}</span>}
+                      </div>
+                      <label className="configuration-images__select">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => handleToggleSelect(image.id)}
+                        />
+                        <span>선택</span>
+                      </label>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add backend services and Google Drive integration to capture configuration images from uploaded videos
- expose new configuration image API endpoints and navigation for reviewing captures
- extend the frontend with a configuration image extraction menu and review page with selection controls

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690440e7326083309b01e87447efb63e