### PR TITLE
Enable card click selection in configuration image editor

### DIFF
--- a/frontend/src/pages/ConfigurationImageEditPage.css
+++ b/frontend/src/pages/ConfigurationImageEditPage.css
@@ -179,15 +179,27 @@
   background: #ffffff;
   overflow: hidden;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.configuration-images__card--selected {
-  border-color: #2f855a;
-  box-shadow: 0 0 0 2px rgba(47, 133, 90, 0.15);
+  cursor: pointer;
 }
 
 .configuration-images__card--recent {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.configuration-images__card--selected {
+  border-color: #2f855a;
+  box-shadow: 0 0 0 3px rgba(47, 133, 90, 0.25);
+}
+
+.configuration-images__card--selected.configuration-images__card--recent {
+  box-shadow:
+    0 0 0 3px rgba(47, 133, 90, 0.25),
+    0 0 0 6px rgba(59, 130, 246, 0.2);
+}
+
+.configuration-images__card:focus-visible {
+  outline: 3px solid rgba(47, 133, 90, 0.45);
+  outline-offset: 2px;
 }
 
 .configuration-images__thumb {

--- a/frontend/src/pages/ConfigurationImageEditPage.tsx
+++ b/frontend/src/pages/ConfigurationImageEditPage.tsx
@@ -1,6 +1,7 @@
 import './ConfigurationImageEditPage.css'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { KeyboardEvent } from 'react'
 
 import { getBackendUrl } from '../config'
 import { navigate } from '../navigation'
@@ -200,6 +201,16 @@ export function ConfigurationImageEditPage({ projectId }: ConfigurationImageEdit
     setSelectedIds(new Set())
   }, [])
 
+  const handleCardKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>, id: string) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        handleToggleSelect(id)
+      }
+    },
+    [handleToggleSelect],
+  )
+
   const handleDeleteSelected = useCallback(async () => {
     if (selectedIds.size === 0 || isDeleting) {
       return
@@ -359,7 +370,15 @@ export function ConfigurationImageEditPage({ projectId }: ConfigurationImageEdit
                   .join(' ')
 
                 return (
-                  <div key={image.id} className={classes}>
+                  <div
+                    key={image.id}
+                    className={classes}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={isSelected}
+                    onClick={() => handleToggleSelect(image.id)}
+                    onKeyDown={(event) => handleCardKeyDown(event, image.id)}
+                  >
                     <div className="configuration-images__thumb">
                       <img
                         src={`${backendUrl}/drive/projects/${encodeURIComponent(projectId)}/configuration-images/${encodeURIComponent(image.id)}`}
@@ -375,10 +394,15 @@ export function ConfigurationImageEditPage({ projectId }: ConfigurationImageEdit
                         {image.isStart && <span className="configuration-images__badge">시작 화면</span>}
                         {timestampLabel && <span>{timestampLabel}</span>}
                       </div>
-                      <label className="configuration-images__select">
+                      <label
+                        className="configuration-images__select"
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => event.stopPropagation()}
+                      >
                         <input
                           type="checkbox"
                           checked={isSelected}
+                          onClick={(event) => event.stopPropagation()}
                           onChange={() => handleToggleSelect(image.id)}
                         />
                         <span>선택</span>


### PR DESCRIPTION
## Summary
- allow selecting configuration image cards directly by clicking or using the keyboard
- enhance the selected styling so chosen configuration images are clearly highlighted

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_69056cf3ae5483309db9fdbb2aae05f4