### PR TITLE
Append security report findings to existing defect report

### DIFF
--- a/backend/app/services/excel_templates/security_report.py
+++ b/backend/app/services/excel_templates/security_report.py
@@ -3,9 +3,33 @@ from __future__ import annotations
 import csv
 import io
 
+from typing import Dict, List
+
 from .defect_report import populate_defect_report
 from .models import DEFECT_REPORT_EXPECTED_HEADERS, SECURITY_REPORT_EXPECTED_HEADERS
 from .utils import AI_CSV_DELIMITER, parse_csv_records
+
+
+def _extract_existing_rows(workbook_bytes: bytes) -> List[Dict[str, str]]:
+    from ..google_drive import defect_reports as drive_defect_reports
+
+    try:
+        _, _, _, rows = drive_defect_reports.parse_defect_report_workbook(workbook_bytes)
+    except Exception:
+        return []
+    return rows
+
+
+def _determine_next_order(rows: List[Dict[str, str]]) -> int:
+    max_order = 0
+    for row in rows:
+        try:
+            order_value = int(str(row.get("order", "")).strip())
+        except (TypeError, ValueError):
+            continue
+        if order_value > max_order:
+            max_order = order_value
+    return max_order + 1
 
 __all__ = [
     "SECURITY_REPORT_EXPECTED_HEADERS",
@@ -15,15 +39,48 @@ __all__ = [
 
 def populate_security_report(workbook_bytes: bytes, csv_text: str) -> bytes:
     records = parse_csv_records(csv_text, SECURITY_REPORT_EXPECTED_HEADERS)
+    existing_rows = _extract_existing_rows(workbook_bytes)
+    next_order = _determine_next_order(existing_rows)
 
     buffer = io.StringIO()
     writer = csv.writer(buffer, delimiter=AI_CSV_DELIMITER)
     writer.writerow(DEFECT_REPORT_EXPECTED_HEADERS)
-    for record in records:
+
+    for row in existing_rows:
         writer.writerow(
             [
-                record.get("순번", ""),
-                record.get("시험환경 OS", ""),
+                row.get("order", ""),
+                row.get("environment", ""),
+                row.get("summary", ""),
+                row.get("severity", ""),
+                row.get("frequency", ""),
+                row.get("quality", ""),
+                row.get("description", ""),
+                row.get("vendorResponse", ""),
+                row.get("fixStatus", ""),
+                row.get("note", ""),
+            ]
+        )
+
+    for record in records:
+        order_value = str(record.get("순번", "")).strip()
+        if not order_value:
+            order_value = str(next_order)
+            next_order += 1
+        else:
+            try:
+                numeric_order = int(order_value)
+            except ValueError:
+                numeric_order = None
+            if numeric_order is not None and numeric_order >= next_order:
+                next_order = numeric_order + 1
+
+        environment = record.get("시험환경 OS", "").strip() or "시험환경 모든 OS"
+
+        writer.writerow(
+            [
+                order_value,
+                environment,
                 record.get("결함 요약", ""),
                 record.get("결함 정도", ""),
                 record.get("발생 빈도", ""),

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -14,6 +14,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.services.excel_templates import (
+    DEFECT_REPORT_EXPECTED_HEADERS,
     FEATURE_LIST_EXPECTED_HEADERS,
     SECURITY_REPORT_EXPECTED_HEADERS,
     TESTCASE_EXPECTED_HEADERS,
@@ -23,6 +24,7 @@ from app.services.excel_templates import (
     populate_security_report,
     populate_testcase_list,
 )
+from app.services.excel_templates.security_report import _extract_existing_rows
 
 _SPREADSHEET_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 
@@ -174,16 +176,77 @@ def test_populate_security_report_fills_rows() -> None:
     )
     csv_text = f"{csv_header}\n{csv_row}"
 
+    existing_rows = _extract_existing_rows(template_bytes)
     updated = populate_security_report(template_bytes, csv_text)
     root = _load_sheet(updated)
 
+    start_row = 6
+    target_row = start_row + len(existing_rows)
+    assert _cell_text(root, f"A{target_row}") == "1"
+    assert _cell_text(root, f"B{target_row}") == "시험환경 모든 OS"
+    assert _cell_text(root, f"C{target_row}") == "요약"
+    assert _cell_text(root, f"D{target_row}") == "H"
+    assert _cell_text(root, f"E{target_row}") == "A"
+    assert _cell_text(root, f"G{target_row}") == "상세 설명"
+    assert _cell_text(root, f"J{target_row}") == "비고"
+
+
+def test_populate_security_report_appends_existing_rows() -> None:
+    template_path = Path("backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    defect_header = "|".join(DEFECT_REPORT_EXPECTED_HEADERS)
+    defect_row = "|".join(
+        [
+            "1",
+            "시험환경 모든 OS",
+            "기존 결함 요약",
+            "M",
+            "R",
+            "보안성",
+            "기존 결함 설명",
+            "",
+            "",
+            "기존 비고",
+        ]
+    )
+    existing_csv = f"{defect_header}\n{defect_row}"
+    existing_bytes = populate_defect_report(template_bytes, existing_csv)
+
+    security_header = "|".join(
+        SECURITY_REPORT_EXPECTED_HEADERS
+        + ["Invicti 결과", "위험도", "발생경로", "조치 가이드", "원본 세부내용", "매핑 유형"]
+    )
+    security_row = "|".join(
+        [
+            "",
+            "",
+            "신규 결함 요약",
+            "H",
+            "A",
+            "보안성",
+            "신규 결함 설명",
+            "",
+            "",
+            "신규 비고",
+            "SQL Injection",
+            "High",
+            "/login",
+            "가이드",
+            "세부",
+            "기준표 매칭",
+        ]
+    )
+    security_csv = f"{security_header}\n{security_row}"
+
+    updated = populate_security_report(existing_bytes, security_csv)
+    root = _load_sheet(updated)
+
     assert _cell_text(root, "A6") == "1"
-    assert _cell_text(root, "B6") == "시험환경 모든 OS"
-    assert _cell_text(root, "C6") == "요약"
-    assert _cell_text(root, "D6") == "H"
-    assert _cell_text(root, "E6") == "A"
-    assert _cell_text(root, "G6") == "상세 설명"
-    assert _cell_text(root, "J6") == "비고"
+    assert _cell_text(root, "C6") == "기존 결함 요약"
+    assert _cell_text(root, "A7") == "2"
+    assert _cell_text(root, "C7") == "신규 결함 요약"
+    assert _cell_text(root, "J7") == "신규 비고"
 
 
 def test_populate_defect_report_accepts_spaced_headers() -> None:


### PR DESCRIPTION
## Summary
- append security report findings to the current defect report workbook instead of overwriting existing rows
- continue defect numbering and apply default environment values when needed
- extend Excel population tests to cover appending behaviour for security report updates

## Testing
- pytest backend/tests/test_excel_population.py -q

------
https://chatgpt.com/codex/tasks/task_e_690570a5a8c08330bdc8d3f26428168d