### PR TITLE
Add Drive project deletion workflow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -417,6 +417,11 @@
   color: #166534;
 }
 
+.drive-card__banner--error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #991b1b;
+}
+
 .drive-card__title {
   margin: 0;
   font-size: 1.45rem;
@@ -1109,14 +1114,12 @@
 .drive-projects__item {
   width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.9rem 1rem;
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.22);
   background: white;
-  cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
 }
@@ -1124,6 +1127,27 @@
 .drive-projects__item:hover {
   transform: translateY(-1px);
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+
+.drive-projects__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.drive-projects__main:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 10px;
 }
 
 .drive-projects__name {
@@ -1135,6 +1159,35 @@
 .drive-projects__meta {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.drive-projects__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.drive-projects__delete-button {
+  border: none;
+  padding: 0.45rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.16);
+  color: #b91c1c;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.drive-projects__delete-button:hover {
+  background: rgba(248, 113, 113, 0.25);
+  color: #991b1b;
+}
+
+.drive-projects__delete-button:disabled {
+  cursor: not-allowed;
+  background: rgba(248, 113, 113, 0.12);
+  color: rgba(185, 28, 28, 0.6);
 }
 
 .drive-empty {

--- a/frontend/src/components/drive/DriveCard.tsx
+++ b/frontend/src/components/drive/DriveCard.tsx
@@ -1,15 +1,24 @@
 import type { PropsWithChildren } from 'react'
 
 type DriveCardVariant = 'default' | 'loading' | 'error'
+type DriveCardBannerVariant = 'success' | 'error'
 
 interface DriveCardProps extends PropsWithChildren {
   variant?: DriveCardVariant
   banner?: string | null
+  bannerVariant?: DriveCardBannerVariant
   role?: string
   ariaBusy?: boolean
 }
 
-export function DriveCard({ variant = 'default', banner, role, ariaBusy, children }: DriveCardProps) {
+export function DriveCard({
+  variant = 'default',
+  banner,
+  bannerVariant = 'success',
+  role,
+  ariaBusy,
+  children,
+}: DriveCardProps) {
   const classes = ['drive-card']
   if (variant === 'loading') {
     classes.push('drive-card--loading')
@@ -20,7 +29,9 @@ export function DriveCard({ variant = 'default', banner, role, ariaBusy, childre
 
   return (
     <section className={classes.join(' ')} role={role} aria-busy={ariaBusy}>
-      {banner && <div className="drive-card__banner drive-card__banner--success">{banner}</div>}
+      {banner && (
+        <div className={`drive-card__banner drive-card__banner--${bannerVariant}`}>{banner}</div>
+      )}
       {children}
     </section>
   )

--- a/frontend/src/components/drive/DriveProjectsList.tsx
+++ b/frontend/src/components/drive/DriveProjectsList.tsx
@@ -3,9 +3,15 @@ import { navigate } from '../../navigation'
 
 interface DriveProjectsListProps {
   projects: DriveProject[]
+  onDeleteProject?: (project: DriveProject) => void
+  deletingProjectId?: string | null
 }
 
-export function DriveProjectsList({ projects }: DriveProjectsListProps) {
+export function DriveProjectsList({
+  projects,
+  onDeleteProject,
+  deletingProjectId,
+}: DriveProjectsListProps) {
   return (
     <ul className="drive-projects__list">
       {projects.map((project) => {
@@ -17,26 +23,49 @@ export function DriveProjectsList({ projects }: DriveProjectsListProps) {
             }).format(modified)
           : null
 
+        const isDeleting = deletingProjectId === project.id
+
         return (
           <li key={project.id}>
-            <button
-              type="button"
-              className="drive-projects__item"
-              onClick={() => {
-                const params = new URLSearchParams()
-                if (project.name) {
-                  params.set('name', project.name)
-                }
-                navigate(
-                  `/projects/${encodeURIComponent(project.id)}${
-                    params.size > 0 ? `?${params.toString()}` : ''
-                  }`,
-                )
-              }}
-            >
-              <span className="drive-projects__name">{project.name}</span>
-              {formatted && <span className="drive-projects__meta">최근 수정 {formatted}</span>}
-            </button>
+            <div className="drive-projects__item">
+              <button
+                type="button"
+                className="drive-projects__main"
+                onClick={() => {
+                  const params = new URLSearchParams()
+                  if (project.name) {
+                    params.set('name', project.name)
+                  }
+                  navigate(
+                    `/projects/${encodeURIComponent(project.id)}${
+                      params.size > 0 ? `?${params.toString()}` : ''
+                    }`,
+                  )
+                }}
+              >
+                <span className="drive-projects__name">{project.name}</span>
+                {formatted && <span className="drive-projects__meta">최근 수정 {formatted}</span>}
+              </button>
+
+              {onDeleteProject && (
+                <div className="drive-projects__actions">
+                  <button
+                    type="button"
+                    className="drive-projects__delete-button"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      event.preventDefault()
+                      onDeleteProject(project)
+                    }}
+                    disabled={isDeleting}
+                    aria-label={`${project.name} 프로젝트 삭제`}
+                    title={`${project.name} 프로젝트 삭제`}
+                  >
+                    {isDeleting ? '삭제 중…' : '삭제'}
+                  </button>
+                </div>
+              )}
+            </div>
           </li>
         )
       })}

--- a/frontend/src/pages/DriveSetupPage.tsx
+++ b/frontend/src/pages/DriveSetupPage.tsx
@@ -9,7 +9,7 @@ import { DriveProjectsList } from '../components/drive/DriveProjectsList'
 import { PageHeader } from '../components/layout/PageHeader'
 import { PageLayout } from '../components/layout/PageLayout'
 import { ProjectCreationModal } from '../components/ProjectCreationModal'
-import type { DriveSetupResponse } from '../types/drive'
+import type { DriveProject, DriveSetupResponse } from '../types/drive'
 import { storeDriveRootFolderId } from '../drive'
 
 type ViewState = 'loading' | 'ready' | 'error'
@@ -22,6 +22,8 @@ export function DriveSetupPage() {
   const [reloadIndex, setReloadIndex] = useState(0)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [failureMessage, setFailureMessage] = useState<string | null>(null)
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null)
 
   useEffect(() => {
     try {
@@ -96,6 +98,7 @@ export function DriveSetupPage() {
 
   const handleOpenModal = () => {
     setSuccessMessage(null)
+    setFailureMessage(null)
     setIsModalOpen(true)
   }
 
@@ -105,11 +108,79 @@ export function DriveSetupPage() {
 
   const handleProjectCreated = () => {
     setSuccessMessage('새 프로젝트 폴더를 생성했습니다.')
+    setFailureMessage(null)
     setReloadIndex((index) => index + 1)
+  }
+
+  const handleProjectDeleted = async (project: DriveProject) => {
+    if (deletingProjectId) {
+      return
+    }
+
+    const confirmed = window.confirm(
+      `정말로 '${project.name}' 프로젝트를 삭제하시겠습니까? 삭제 후에는 복구할 수 없습니다.`,
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    setSuccessMessage(null)
+    setFailureMessage(null)
+    setDeletingProjectId(project.id)
+
+    try {
+      const response = await fetch(`${backendUrl}/drive/projects/${project.id}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        let detail = `'${project.name}' 프로젝트를 삭제하는 중 오류가 발생했습니다.`
+        try {
+          const payload = await response.json()
+          if (payload && typeof payload.detail === 'string') {
+            detail = payload.detail
+          }
+        } catch {
+          const text = await response.text()
+          if (text) {
+            detail = text
+          }
+        }
+        throw new Error(detail)
+      }
+
+      setSuccessMessage(`'${project.name}' 프로젝트를 삭제했습니다.`)
+      setReloadIndex((index) => index + 1)
+    } catch (error) {
+      const fallback =
+        error instanceof Error
+          ? error.message
+          : '프로젝트 삭제 중 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      setFailureMessage(fallback)
+    } finally {
+      setDeletingProjectId(null)
+    }
   }
 
   const projects = result?.projects ?? []
   const folderName = result?.folderName ?? 'gs'
+
+  const banner = (() => {
+    if (failureMessage) {
+      return { message: failureMessage, variant: 'error' as const }
+    }
+    if (result?.folderCreated) {
+      return {
+        message: `'${result.folderName}' 폴더를 Google Drive에 새로 만들었습니다.`,
+        variant: 'success' as const,
+      }
+    }
+    if (successMessage) {
+      return { message: successMessage, variant: 'success' as const }
+    }
+    return null
+  })()
 
   return (
     <PageLayout>
@@ -139,13 +210,7 @@ export function DriveSetupPage() {
         )}
 
         {viewState === 'ready' && result && (
-          <DriveCard
-            banner={
-              result.folderCreated
-                ? `'${result.folderName}' 폴더를 Google Drive에 새로 만들었습니다.`
-                : successMessage
-            }
-          >
+          <DriveCard banner={banner?.message ?? null} bannerVariant={banner?.variant}>
             <h2 className="drive-card__title">프로젝트 선택</h2>
             <p className="drive-card__description">
               {projects.length > 0
@@ -155,7 +220,11 @@ export function DriveSetupPage() {
 
             {projects.length > 0 ? (
               <>
-                <DriveProjectsList projects={projects} />
+                <DriveProjectsList
+                  projects={projects}
+                  onDeleteProject={handleProjectDeleted}
+                  deletingProjectId={deletingProjectId}
+                />
                 <DriveActionButton variant="compact" onClick={handleOpenModal}>
                   새 프로젝트 만들기
                 </DriveActionButton>


### PR DESCRIPTION
## Summary
- add a dedicated delete control to each Drive project list item with proper styling and disabled state
- handle Drive project deletions from the setup page with confirmation, banner feedback, and list reloads
- extend the Drive card banner to support error styling for failure messaging

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905eaa3df808330960dfcc149f1460f