### PR TITLE
Handle merged minor categories in testcase spreadsheets

### DIFF
--- a/backend/app/services/excel_templates/testcases.py
+++ b/backend/app/services/excel_templates/testcases.py
@@ -20,5 +20,5 @@ def populate_testcase_list(workbook_bytes: bytes, csv_text: str) -> bytes:
         sheet_bytes = source.read(XLSX_SHEET_PATH)
     populator = WorksheetPopulator(sheet_bytes, start_row=TESTCASE_START_ROW, columns=TESTCASE_COLUMNS)
     populator.populate(records)
-    populator.merge_repeated_cells(records, columns=("A", "B"))
+    populator.merge_repeated_cells(records, columns=("A", "B", "C"))
     return replace_sheet_bytes(workbook_bytes, populator.to_bytes())

--- a/backend/app/services/google_drive/testcases.py
+++ b/backend/app/services/google_drive/testcases.py
@@ -145,6 +145,7 @@ def parse_testcase_workbook(workbook_bytes: bytes) -> Tuple[str, int, List[str],
     column_map: Dict[str, int] = {}
     last_major: str = ""
     last_middle: str = ""
+    last_minor: str = ""
 
     try:
         sheet = workbook.active
@@ -247,17 +248,34 @@ def parse_testcase_workbook(workbook_bytes: bytes) -> Tuple[str, int, List[str],
             if not has_values:
                 continue
 
+            prev_major = last_major
+            prev_middle = last_middle
+
             major = row_data.get("majorCategory", "").strip()
             if major:
                 last_major = major
             else:
                 row_data["majorCategory"] = last_major
+                major = last_major
 
             middle = row_data.get("middleCategory", "").strip()
             if middle:
                 last_middle = middle
             else:
                 row_data["middleCategory"] = last_middle
+                middle = last_middle
+
+            if major != prev_major:
+                last_minor = ""
+
+            if middle != prev_middle:
+                last_minor = ""
+
+            minor = row_data.get("minorCategory", "").strip()
+            if minor:
+                last_minor = minor
+            elif last_minor:
+                row_data["minorCategory"] = last_minor
 
             extracted_rows.append(row_data)
 

--- a/backend/tests/test_google_drive_testcases_module.py
+++ b/backend/tests/test_google_drive_testcases_module.py
@@ -57,6 +57,20 @@ def sample_workbook_bytes() -> bytes:
         [
             None,
             None,
+            None,
+            "TC-001A",
+            "OTP 입력 지연",
+            "지연된 OTP 입력",
+            "인증 실패",
+            "F",
+            "지연 경고 메시지가 표시되어야 함",
+            "--",
+        ]
+    )
+    sheet.append(
+        [
+            None,
+            None,
             "OTP 재시도",
             "TC-002",
             "만료된 OTP 입력",
@@ -93,11 +107,13 @@ def test_parse_testcase_workbook_extracts_rows(sample_workbook_bytes: bytes) -> 
     assert sheet_name == "테스트케이스"
     assert start_row >= 3
     assert headers[:3] == ["대분류", "중분류", "소분류"]
-    assert len(rows) == 3
+    assert len(rows) == 4
     assert rows[0]["testcaseId"] == "TC-001"
     assert rows[1]["majorCategory"] == "로그인"
     assert rows[1]["middleCategory"] == "인증"
+    assert rows[1]["minorCategory"] == "OTP"
     assert rows[1]["expected"] == "인증 실패"
+    assert rows[2]["minorCategory"] == "OTP 재시도"
 
 
 def test_build_testcase_rows_csv_roundtrip(sample_workbook_bytes: bytes) -> None:
@@ -106,4 +122,5 @@ def test_build_testcase_rows_csv_roundtrip(sample_workbook_bytes: bytes) -> None
 
     # When we repopulate the template with the csv, it should contain our headers
     assert "테스트 케이스 ID" in csv_text
+    assert "TC-001A" in csv_text
     assert "TC-002" in csv_text


### PR DESCRIPTION
## Summary
- ensure testcase parsing restores merged minor category values by carrying forward the previous value
- merge repeated minor category cells when repopulating the testcase workbook template
- cover the behaviour with an updated testcase parsing test fixture

## Testing
- pytest backend/tests/test_google_drive_testcases_module.py

------
https://chatgpt.com/codex/tasks/task_e_69061c1bcdac83309dafec1a0c3ac8cb