### PR TITLE
feat: add reset confirmation modal to testcase workflow

### DIFF
--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
@@ -432,6 +432,13 @@
   gap: 0.75rem;
 }
 
+.testcase-workflow__step-actions-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
 .testcase-workflow__summary {
   width: 100%;
   overflow-x: auto;
@@ -469,4 +476,54 @@
   .testcase-workflow__table {
     min-width: 720px;
   }
+}
+
+.testcase-workflow__modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.testcase-workflow__modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.testcase-workflow__modal {
+  position: relative;
+  z-index: 1;
+  width: calc(100% - 2rem);
+  max-width: 420px;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 24px 60px -20px rgba(15, 23, 42, 0.45);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.testcase-workflow__modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.testcase-workflow__modal-description {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.testcase-workflow__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
@@ -1,6 +1,6 @@
 import './TestcaseWorkflow.css'
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { navigate } from '../../navigation'
 import { useBackgroundTasks } from '../../app/background/BackgroundTaskContext'
@@ -46,6 +46,22 @@ interface TestcaseWorkflowProps {
   projectName?: string
 }
 
+interface TestcaseWorkflowDraft {
+  version: 1
+  savedAt: string
+  step: Step
+  projectOverview: string
+  groups: Array<{
+    feature: FeatureRow
+    scenarioCount: number
+    scenarios: ScenarioEntry[]
+    rewriteMessages: ConversationMessage[]
+    rewriteInput: string
+    isCollapsed: boolean
+  }>
+  nextId: number
+}
+
 type Step = 'feature' | 'scenarios'
 
 const FEATURE_FILE_TYPES: FileType[] = ['xlsx', 'xls', 'csv']
@@ -81,7 +97,120 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
   const [groups, setGroups] = useState<ScenarioGroupState[]>([])
   const [finalStatus, setFinalStatus] = useState<'idle' | 'loading' | 'error'>('idle')
   const [finalError, setFinalError] = useState<string | null>(null)
+  const [draftFeedback, setDraftFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(
+    null,
+  )
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
   const idRef = useRef(0)
+  const storageKey = useMemo(() => `tta:testcase-workflow:${projectId}`, [projectId])
+
+  const clearDraft = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    window.localStorage.removeItem(storageKey)
+  }, [storageKey])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const raw = window.localStorage.getItem(storageKey)
+    if (!raw) {
+      return
+    }
+
+    try {
+      const draft = JSON.parse(raw) as TestcaseWorkflowDraft
+      if (!draft || draft.version !== 1) {
+        return
+      }
+
+      const shouldRestore = window.confirm('이전에 저장된 테스트케이스 작성 중간 내역이 있습니다. 불러올까요?')
+      if (!shouldRestore) {
+        return
+      }
+
+      setProjectOverview(draft.projectOverview ?? '')
+
+      const normalizedGroups: ScenarioGroupState[] = []
+      let nextIdCounter = typeof draft.nextId === 'number' && Number.isFinite(draft.nextId) ? draft.nextId : 0
+
+      for (const group of draft.groups ?? []) {
+        if (!group || !group.feature) {
+          continue
+        }
+
+        const normalizedScenarios: ScenarioEntry[] = []
+        for (const scenario of group.scenarios ?? []) {
+          if (!scenario) {
+            continue
+          }
+          let scenarioId = typeof scenario.id === 'string' && scenario.id.trim().length > 0 ? scenario.id : ''
+          if (!scenarioId) {
+            nextIdCounter += 1
+            scenarioId = `scenario-${nextIdCounter}`
+          } else {
+            const match = scenarioId.match(/(\d+)$/)
+            if (match) {
+              const parsed = Number.parseInt(match[1] ?? '0', 10)
+              if (!Number.isNaN(parsed)) {
+                nextIdCounter = Math.max(nextIdCounter, parsed)
+              }
+            }
+          }
+          normalizedScenarios.push({
+            id: scenarioId,
+            scenario: scenario.scenario ?? '',
+            input: scenario.input ?? '',
+            expected: scenario.expected ?? '',
+          })
+        }
+
+        normalizedGroups.push({
+          feature: group.feature,
+          scenarios: normalizedScenarios,
+          files: [],
+          scenarioCount: Math.max(3, Math.min(5, group.scenarioCount ?? 3)),
+          status: 'idle',
+          error: null,
+          rewriteMessages: group.rewriteMessages ?? [],
+          rewriteInput: group.rewriteInput ?? '',
+          rewriteStatus: 'idle',
+          rewriteError: null,
+          isCollapsed: Boolean(group.isCollapsed),
+        })
+      }
+
+      idRef.current = nextIdCounter
+      setGroups(normalizedGroups)
+      setFeatureStatus('idle')
+      setFeatureError(null)
+      setFeatureFiles([])
+      setStep(normalizedGroups.length > 0 ? 'scenarios' : draft.step ?? 'feature')
+      setDraftFeedback({ type: 'success', message: '중간 저장된 내용을 불러왔습니다.' })
+    } catch (error) {
+      console.error('Failed to restore testcase workflow draft', error)
+      window.localStorage.removeItem(storageKey)
+      setDraftFeedback({ type: 'error', message: '저장된 내용을 불러오지 못했습니다. 다시 저장해 주세요.' })
+    }
+  }, [storageKey])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    if (!draftFeedback) {
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setDraftFeedback(null)
+    }, 5000)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [draftFeedback])
 
   const handleUploadFeatureList = useCallback(
     async (file: File | null) => {
@@ -641,6 +770,7 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
         query ? `?${query}` : ''
       }`
       if (!taskHandle.signal.aborted) {
+        clearDraft()
         taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '테스트케이스 생성 완료')
         navigate(targetUrl)
       }
@@ -653,7 +783,68 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
       setFinalError(message)
       taskHandle.fail(message)
     }
-  }, [backendUrl, groups, projectId, projectOverview, projectName, startTask])
+  }, [backendUrl, clearDraft, groups, projectId, projectOverview, projectName, startTask])
+
+  const handleSaveDraft = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      const draft: TestcaseWorkflowDraft = {
+        version: 1,
+        savedAt: new Date().toISOString(),
+        step,
+        projectOverview,
+        groups: groups.map((group) => ({
+          feature: group.feature,
+          scenarioCount: group.scenarioCount,
+          scenarios: group.scenarios.map((scenario) => ({ ...scenario })),
+          rewriteMessages: group.rewriteMessages.map((message) => ({ ...message })),
+          rewriteInput: group.rewriteInput,
+          isCollapsed: group.isCollapsed,
+        })),
+        nextId: idRef.current,
+      }
+
+      window.localStorage.setItem(storageKey, JSON.stringify(draft))
+      setDraftFeedback({
+        type: 'success',
+        message: '중간 저장했습니다. 같은 브라우저에서 다시 열면 이어서 작업할 수 있습니다.',
+      })
+    } catch (error) {
+      console.error('Failed to save testcase workflow draft', error)
+      setDraftFeedback({ type: 'error', message: '중간 저장에 실패했습니다. 다시 시도해 주세요.' })
+    }
+  }, [groups, idRef, projectOverview, step, storageKey])
+
+  const canSaveDraft = useMemo(
+    () => projectOverview.trim().length > 0 || groups.some((group) => group.scenarios.length > 0),
+    [groups, projectOverview],
+  )
+
+  const handleRequestReset = useCallback(() => {
+    setShowResetConfirm(true)
+  }, [])
+
+  const handleCancelReset = useCallback(() => {
+    setShowResetConfirm(false)
+  }, [])
+
+  const handleConfirmReset = useCallback(() => {
+    setShowResetConfirm(false)
+    setStep('feature')
+    setProjectOverview('')
+    setFeatureStatus('idle')
+    setFeatureError(null)
+    setFeatureFiles([])
+    setGroups([])
+    setFinalStatus('idle')
+    setFinalError(null)
+    setDraftFeedback(null)
+    idRef.current = 0
+    clearDraft()
+  }, [clearDraft])
 
   return (
     <div className="testcase-workflow">
@@ -935,18 +1126,43 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
           </div>
 
           <div className="testcase-workflow__step-actions">
-            <button type="button" className="testcase-workflow__secondary testcase-workflow__button" onClick={() => setStep('feature')}>
-              기능리스트 단계로 돌아가기
-            </button>
             <button
               type="button"
-              className="testcase-workflow__button"
-              onClick={handleFinalize}
-              disabled={!canProceedToReview || finalStatus === 'loading'}
+              className="testcase-workflow__secondary testcase-workflow__button"
+              onClick={handleRequestReset}
             >
-              {finalStatus === 'loading' ? '완료 중…' : '완료하고 테스트케이스 생성'}
+              처음 단계로 돌아가기
             </button>
+            <div className="testcase-workflow__step-actions-group">
+              <button
+                type="button"
+                className="testcase-workflow__secondary testcase-workflow__button"
+                onClick={handleSaveDraft}
+                disabled={!canSaveDraft}
+              >
+                중간 저장
+              </button>
+              <button
+                type="button"
+                className="testcase-workflow__button"
+                onClick={handleFinalize}
+                disabled={!canProceedToReview || finalStatus === 'loading'}
+              >
+                {finalStatus === 'loading' ? '완료 중…' : '완료하고 테스트케이스 생성'}
+              </button>
+            </div>
           </div>
+
+          {draftFeedback && (
+            <div
+              className={`testcase-workflow__status testcase-workflow__status--${
+                draftFeedback.type === 'success' ? 'success' : 'error'
+              }`}
+              role={draftFeedback.type === 'error' ? 'alert' : 'status'}
+            >
+              {draftFeedback.message}
+            </div>
+          )}
 
           {finalStatus === 'error' && finalError && (
             <div className="testcase-workflow__status testcase-workflow__status--error">{finalError}</div>
@@ -955,6 +1171,37 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
       )}
 
 
+      {showResetConfirm && (
+        <div className="testcase-workflow__modal-overlay" role="presentation">
+          <div className="testcase-workflow__modal-backdrop" onClick={handleCancelReset} />
+          <div
+            className="testcase-workflow__modal"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="testcase-workflow-reset-title"
+            aria-describedby="testcase-workflow-reset-description"
+          >
+            <h3 id="testcase-workflow-reset-title" className="testcase-workflow__modal-title">
+              저장한 내용을 삭제하고 처음 단계로 돌아갈까요?
+            </h3>
+            <p id="testcase-workflow-reset-description" className="testcase-workflow__modal-description">
+              돌아가기를 선택하면 중간 저장된 내용과 현재 작성 중인 정보가 모두 삭제됩니다. 계속하시겠어요?
+            </p>
+            <div className="testcase-workflow__modal-actions">
+              <button
+                type="button"
+                className="testcase-workflow__secondary testcase-workflow__button"
+                onClick={handleCancelReset}
+              >
+                취소
+              </button>
+              <button type="button" className="testcase-workflow__button" onClick={handleConfirmReset}>
+                저장 안 하고 돌아가기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- rename the step navigation control to "처음 단계로 돌아가기" and reorganize the footer actions for better balance
- prompt users with a confirmation modal that clears saved and in-progress data before resetting the workflow
- style the modal and action groups to match the refreshed layout

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690956e99a988330a63794d5debc5b70