### PR TITLE
Fix Excel namespace handling for injected images

### DIFF
--- a/backend/app/services/excel_templates.py
+++ b/backend/app/services/excel_templates.py
@@ -57,6 +57,10 @@ _CONTENT_TYPES_NS = "http://schemas.openxmlformats.org/package/2006/content-type
 _EMU_PER_PIXEL = 9525
 _IMAGE_VERTICAL_GAP_PX = 4
 
+ET.register_namespace("xdr", _DRAWING_NS)
+ET.register_namespace("a", _DRAWING_A_NS)
+ET.register_namespace("r", _REL_NS)
+
 
 @dataclass(frozen=True)
 class ColumnSpec:
@@ -1329,11 +1333,8 @@ def _inject_defect_images(
     )
     updated_rels = ET.tostring(rels_root, encoding="utf-8", xml_declaration=True)
 
-    drawing_root = ET.Element(
-        f"{{{_DRAWING_NS}}}wsDr",
-        {"xmlns:xdr": _DRAWING_NS, "xmlns:a": _DRAWING_A_NS},
-    )
-    drawing_rels_root = ET.Element(f"{{{_REL_NS}}}Relationships")
+    drawing_root = ET.Element(f"{{{_DRAWING_NS}}}wsDr")
+    drawing_rels_root = ET.Element("Relationships", {"xmlns": _REL_NS})
     used_names: Dict[str, int] = {}
     image_entries: List[Tuple[str, bytes]] = []
 
@@ -1389,7 +1390,7 @@ def _inject_defect_images(
 
         ET.SubElement(
             drawing_rels_root,
-            f"{{{_REL_NS}}}Relationship",
+            "Relationship",
             {
                 "Id": rel_id,
                 "Type": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",

--- a/backend/app/services/excel_templates/defect_report.py
+++ b/backend/app/services/excel_templates/defect_report.py
@@ -28,6 +28,10 @@ from .models import (
 from .utils import append_attachment_note, parse_csv_records, safe_int
 from .workbook import WorksheetPopulator, column_to_index, replace_sheet_bytes
 
+ET.register_namespace("xdr", DRAWING_NS)
+ET.register_namespace("a", DRAWING_A_NS)
+ET.register_namespace("r", REL_NS)
+
 __all__ = [
     "DEFECT_REPORT_COLUMNS",
     "DEFECT_REPORT_EXPECTED_HEADERS",
@@ -265,11 +269,8 @@ def _inject_defect_images(
     )
     updated_rels = ET.tostring(rels_root, encoding="utf-8", xml_declaration=True)
 
-    drawing_root = ET.Element(
-        f"{{{DRAWING_NS}}}wsDr",
-        {"xmlns:xdr": DRAWING_NS, "xmlns:a": DRAWING_A_NS},
-    )
-    drawing_rels_root = ET.Element(f"{{{REL_NS}}}Relationships")
+    drawing_root = ET.Element(f"{{{DRAWING_NS}}}wsDr")
+    drawing_rels_root = ET.Element("Relationships", {"xmlns": REL_NS})
     used_names: Dict[str, int] = {}
     image_entries: List[Tuple[str, bytes]] = []
 
@@ -325,7 +326,7 @@ def _inject_defect_images(
 
         ET.SubElement(
             drawing_rels_root,
-            f"{{{REL_NS}}}Relationship",
+            "Relationship",
             {
                 "Id": rel_id,
                 "Type": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import io
 import sys
 import zipfile
@@ -18,6 +19,7 @@ from app.services.excel_templates import (
     FEATURE_LIST_EXPECTED_HEADERS,
     SECURITY_REPORT_EXPECTED_HEADERS,
     TESTCASE_EXPECTED_HEADERS,
+    DefectReportImage,
     extract_feature_list_overview,
     populate_defect_report,
     populate_feature_list,
@@ -182,7 +184,8 @@ def test_populate_security_report_fills_rows() -> None:
 
     start_row = 6
     target_row = start_row + len(existing_rows)
-    assert _cell_text(root, f"A{target_row}") == "1"
+    expected_order = str(len(existing_rows) + 1)
+    assert _cell_text(root, f"A{target_row}") == expected_order
     assert _cell_text(root, f"B{target_row}") == "시험환경 모든 OS"
     assert _cell_text(root, f"C{target_row}") == "요약"
     assert _cell_text(root, f"D{target_row}") == "H"
@@ -247,6 +250,45 @@ def test_populate_security_report_appends_existing_rows() -> None:
     assert _cell_text(root, "A7") == "2"
     assert _cell_text(root, "C7") == "신규 결함 요약"
     assert _cell_text(root, "J7") == "신규 비고"
+
+
+def test_populate_defect_report_injects_images_with_relationship_namespace() -> None:
+    template_path = Path("backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    header = "|".join(DEFECT_REPORT_EXPECTED_HEADERS)
+    row = "|".join(
+        [
+            "1",
+            "Windows",
+            "요약",
+            "High",
+            "Frequent",
+            "품질",
+            "설명",
+            "응답",
+            "수정",
+            "비고",
+        ]
+    )
+    csv_text = f"{header}\n{row}"
+
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lW+7TQAAAABJRU5ErkJggg=="
+    )
+
+    workbook_bytes = populate_defect_report(
+        template_bytes,
+        csv_text,
+        images={1: [DefectReportImage(file_name="image.png", content=image_bytes)]},
+    )
+
+    with zipfile.ZipFile(io.BytesIO(workbook_bytes), "r") as zf:
+        drawing_xml = zf.read("xl/drawings/drawing2.xml")
+
+    assert b"<xdr:wsDr" in drawing_xml
+    assert b"xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"" in drawing_xml
+    assert b"r:embed=\"rId1\"" in drawing_xml
 
 
 def test_populate_defect_report_accepts_spaced_headers() -> None:


### PR DESCRIPTION
## Summary
- ensure both defect-report image injectors register drawing namespaces so generated XML uses xdr/a/r prefixes
- add regression coverage for the drawing namespace and adjust the security report expectation to account for seeded rows

## Testing
- pytest backend/tests/test_excel_population.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5c8c37788330b8a5e799ab7a9730)