### PR TITLE
Allow project creation with PDF agreements

### DIFF
--- a/backend/app/services/google_drive/metadata.py
+++ b/backend/app/services/google_drive/metadata.py
@@ -1,12 +1,13 @@
-"""Utilities for extracting project metadata from DOCX documents."""
+"""Utilities for extracting project metadata from 시험 합의서 문서."""
 from __future__ import annotations
 
 import io
 import re
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Sequence
 
 from docx import Document
 from fastapi import HTTPException
+from pypdf import PdfReader
 
 EXAM_NUMBER_PATTERN = re.compile(r"GS-[A-Z]-\d{2}-\d{4}")
 
@@ -21,7 +22,35 @@ def normalize_label(value: str) -> str:
     return re.sub(r"\s+", "", value or "")
 
 
-def extract_project_metadata(file_bytes: bytes) -> Dict[str, str]:
+def extract_project_metadata(file_bytes: bytes, *, file_extension: Optional[str] = None) -> Dict[str, str]:
+    """Extract metadata required for project creation from DOCX or PDF files."""
+
+    normalized_extension = (file_extension or "").lower().lstrip(".")
+
+    if normalized_extension == "pdf":
+        return _extract_project_metadata_from_pdf(file_bytes)
+
+    try:
+        return _extract_project_metadata_from_docx(file_bytes)
+    except HTTPException as exc:
+        # If the caller did not provide a reliable extension, attempt PDF parsing
+        # as a graceful fallback before surfacing the DOCX error.
+        if not file_extension:
+            try:
+                return _extract_project_metadata_from_pdf(file_bytes)
+            except HTTPException:
+                pass
+        raise exc
+
+
+def build_project_folder_name(metadata: Dict[str, str]) -> str:
+    exam_number = metadata.get("exam_number", "").strip()
+    company_name = metadata.get("company_name", "").strip()
+    product_name = metadata.get("product_name", "").strip()
+    return f"[{exam_number}] {company_name} - {product_name}"
+
+
+def _extract_project_metadata_from_docx(file_bytes: bytes) -> Dict[str, str]:
     try:
         document = Document(io.BytesIO(file_bytes))
     except Exception as exc:  # pragma: no cover - library level validation
@@ -30,11 +59,14 @@ def extract_project_metadata(file_bytes: bytes) -> Dict[str, str]:
     exam_number: Optional[str] = None
     company_name: Optional[str] = None
     product_name: Optional[str] = None
+    collected_lines: list[str] = []
 
     def _extract_from_cells(cells: Iterable[str]) -> None:
         nonlocal exam_number, company_name, product_name
         cell_iter = iter(cells)
         for label, value in zip(cell_iter, cell_iter):
+            collected_lines.append(label)
+            collected_lines.append(value)
             normalized_label = normalize_label(label)
             stripped_value = value.strip()
             if not stripped_value:
@@ -46,37 +78,80 @@ def extract_project_metadata(file_bytes: bytes) -> Dict[str, str]:
             elif normalized_label == "제조자":
                 company_name = stripped_value
             elif normalized_label.startswith("제품명및버전"):
-                lines = [line.strip() for line in stripped_value.split("\n") if line.strip()]
-                if lines:
-                    last_line = lines[-1]
-                    if ":" in last_line:
-                        product_name = last_line.split(":", 1)[1].strip()
-                    else:
-                        product_name = last_line
+                candidate = _extract_product_name(stripped_value)
+                if candidate:
+                    product_name = candidate
 
     for table in document.tables:
         cells: list[str] = []
         for row in table.rows:
             if len(row.cells) >= 2:
-                if row.cells[0].text.strip() and row.cells[1].text.strip():
-                    cells.append(row.cells[0].text.strip())
-                    cells.append(row.cells[1].text.strip())
-                if len(row.cells) >= 4 and row.cells[2].text.strip() and row.cells[3].text.strip():
-                    cells.append(row.cells[2].text.strip())
-                    cells.append(row.cells[3].text.strip())
+                left_label = row.cells[0].text.strip()
+                left_value = row.cells[1].text.strip()
+                if left_label and left_value:
+                    cells.append(left_label)
+                    cells.append(left_value)
+            if len(row.cells) >= 4:
+                right_label = row.cells[2].text.strip()
+                right_value = row.cells[3].text.strip()
+                if right_label and right_value:
+                    cells.append(right_label)
+                    cells.append(right_value)
 
         if cells:
             _extract_from_cells(cells)
 
-    if exam_number is None:
-        combined_text = "\n".join(
-            paragraph.text.strip()
-            for paragraph in document.paragraphs
-            if paragraph.text and paragraph.text.strip()
-        )
+    paragraph_lines = [
+        paragraph.text.strip()
+        for paragraph in document.paragraphs
+        if paragraph.text and paragraph.text.strip()
+    ]
+    collected_lines.extend(paragraph_lines)
+
+    metadata = _finalize_metadata_from_lines(collected_lines, exam_number, company_name, product_name)
+    return metadata
+
+
+def _extract_project_metadata_from_pdf(file_bytes: bytes) -> Dict[str, str]:
+    try:
+        reader = PdfReader(io.BytesIO(file_bytes))
+    except Exception as exc:  # pragma: no cover - library level validation
+        raise HTTPException(status_code=422, detail="시험 합의서 파일을 읽지 못했습니다.") from exc
+
+    lines: list[str] = []
+    for page in reader.pages:
+        try:
+            text = page.extract_text() or ""
+        except Exception as exc:  # pragma: no cover - library level validation
+            raise HTTPException(status_code=422, detail="시험 합의서 파일을 읽지 못했습니다.") from exc
+        if text:
+            lines.extend(text.splitlines())
+
+    metadata = _finalize_metadata_from_lines(lines, None, None, None)
+    return metadata
+
+
+def _finalize_metadata_from_lines(
+    lines: Iterable[str],
+    exam_number: Optional[str],
+    company_name: Optional[str],
+    product_name: Optional[str],
+) -> Dict[str, str]:
+    meaningful_lines = [line.strip() for line in lines if line and line.strip()]
+    combined_text = "\n".join(meaningful_lines)
+
+    if not exam_number:
         match = EXAM_NUMBER_PATTERN.search(combined_text)
         if match:
             exam_number = match.group(0)
+
+    if not company_name:
+        company_name = _extract_labeled_value(meaningful_lines, ("제조자",))
+
+    if not product_name:
+        product_name = _extract_labeled_value(meaningful_lines, ("제품명및버전",))
+        if product_name:
+            product_name = _extract_product_name(product_name)
 
     if not exam_number:
         raise HTTPException(status_code=422, detail="시험신청 번호를 찾을 수 없습니다.")
@@ -94,8 +169,69 @@ def extract_project_metadata(file_bytes: bytes) -> Dict[str, str]:
     }
 
 
-def build_project_folder_name(metadata: Dict[str, str]) -> str:
-    exam_number = metadata.get("exam_number", "").strip()
-    company_name = metadata.get("company_name", "").strip()
-    product_name = metadata.get("product_name", "").strip()
-    return f"[{exam_number}] {company_name} - {product_name}"
+def _extract_labeled_value(lines: Sequence[str], target_labels: Sequence[str]) -> Optional[str]:
+    normalized_targets = tuple(normalize_label(label) for label in target_labels)
+
+    def _is_target(label: str) -> bool:
+        return any(label.startswith(target) for target in normalized_targets)
+
+    for index, line in enumerate(lines):
+        label, inline_value = _split_label_and_value(line)
+        if not _is_target(label):
+            continue
+
+        candidate = inline_value.strip()
+        if not candidate:
+            candidate = _next_value(lines, index + 1, normalized_targets)
+        candidate = _strip_leading_label(candidate, normalized_targets)
+        if candidate:
+            return candidate.strip()
+
+    return None
+
+
+def _split_label_and_value(line: str) -> tuple[str, str]:
+    for separator in (":", "："):
+        if separator in line:
+            left, right = line.split(separator, 1)
+            return normalize_label(left), right
+    return normalize_label(line), ""
+
+
+def _next_value(lines: Sequence[str], start: int, normalized_targets: Sequence[str]) -> str:
+    for candidate in lines[start:]:
+        stripped = candidate.strip()
+        if not stripped:
+            continue
+        candidate_label = normalize_label(stripped)
+        if any(candidate_label.startswith(target) for target in normalized_targets):
+            continue
+        return stripped
+    return ""
+
+
+def _strip_leading_label(value: str, normalized_targets: Sequence[str]) -> str:
+    stripped = value.strip()
+    if not stripped:
+        return stripped
+
+    for separator in (":", "："):
+        if separator in stripped:
+            potential_label, remainder = stripped.split(separator, 1)
+            normalized = normalize_label(potential_label)
+            if any(normalized.startswith(target) for target in normalized_targets):
+                return remainder.strip()
+    return stripped
+
+
+def _extract_product_name(raw_value: str) -> Optional[str]:
+    lines = [line.strip() for line in raw_value.split("\n") if line.strip()]
+    if not lines:
+        return None
+
+    last_line = lines[-1]
+    for separator in (":", "："):
+        if separator in last_line:
+            _, remainder = last_line.split(separator, 1)
+            return remainder.strip()
+    return last_line.strip() or None

--- a/backend/app/services/google_drive/service.py
+++ b/backend/app/services/google_drive/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from fastapi import HTTPException, UploadFile
@@ -1132,11 +1133,22 @@ class GoogleDriveService:
             raise HTTPException(status_code=422, detail="업로드할 파일이 필요합니다.")
 
         agreement_file = files[0]
-        if not agreement_file.filename or not agreement_file.filename.lower().endswith(".docx"):
-            raise HTTPException(status_code=422, detail="시험 합의서는 DOCX 파일이어야 합니다.")
+        allowed_extensions = {".docx", ".pdf"}
+        filename = agreement_file.filename or ""
+        extension = Path(filename).suffix.lower()
+        content_type = agreement_file.content_type or ""
+
+        if extension not in allowed_extensions:
+            if "pdf" in content_type:
+                extension = ".pdf"
+            elif "officedocument.wordprocessingml.document" in content_type:
+                extension = ".docx"
+
+        if extension not in allowed_extensions:
+            raise HTTPException(status_code=422, detail="시험 합의서는 DOCX 또는 PDF 파일이어야 합니다.")
 
         agreement_bytes = await agreement_file.read()
-        metadata = extract_project_metadata(agreement_bytes)
+        metadata = extract_project_metadata(agreement_bytes, file_extension=extension)
         project_name = build_project_folder_name(metadata)
         if not project_name:
             raise HTTPException(status_code=422, detail="생성할 프로젝트 이름을 결정할 수 없습니다.")
@@ -1170,23 +1182,34 @@ class GoogleDriveService:
 
         uploaded_files: List[Dict[str, Any]] = []
 
-        agreement_name = agreement_file.filename or "시험 합의서.docx"
+        default_name = "시험 합의서.pdf" if extension == ".pdf" else "시험 합의서.docx"
+        agreement_name = agreement_file.filename or default_name
         agreement_name = replace_placeholders(agreement_name, metadata["exam_number"])
         file_info, active_tokens = await self._client.upload_file_to_folder(
             active_tokens,
             file_name=agreement_name,
             parent_id=project_id,
             content=agreement_bytes,
-            content_type=agreement_file.content_type
-            or "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            content_type=
+            agreement_file.content_type
+            or (
+                "application/pdf"
+                if extension == ".pdf"
+                else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
         )
         uploaded_files.append(
             {
                 "id": file_info.get("id"),
                 "name": file_info.get("name", agreement_name),
                 "size": len(agreement_bytes),
-                "contentType": agreement_file.content_type
-                or "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "contentType":
+                agreement_file.content_type
+                or (
+                    "application/pdf"
+                    if extension == ".pdf"
+                    else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                ),
             }
         )
         await agreement_file.close()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ pydantic==2.11.9
 pydantic_core==2.33.2
 python-dotenv==1.1.1
 python-multipart==0.0.9
+pypdf==5.1.0
 beautifulsoup4==4.12.3
 thefuzz==0.22.1
 PyYAML==6.0.2

--- a/backend/tests/test_google_drive_metadata.py
+++ b/backend/tests/test_google_drive_metadata.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("docx")
+pytest.importorskip("pypdf")
 from docx import Document
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
@@ -34,12 +35,60 @@ def _build_sample_agreement() -> bytes:
     return buffer.getvalue()
 
 
+def _build_sample_pdf_agreement() -> bytes:
+    stream_content = (
+        "BT /F1 12 Tf 72 720 Td (시험 신청 번호 : GS-B-12-3456) Tj "
+        "T* (제조자 : Acme Corp) Tj "
+        "T* (제품명 및 버전 : Wonder Widget 1.0) Tj ET"
+    ).encode("utf-8")
+
+    buffer = io.BytesIO()
+    buffer.write(b"%PDF-1.4\n")
+    offsets: list[int] = []
+
+    def _write_object(payload: bytes) -> None:
+        offsets.append(buffer.tell())
+        buffer.write(payload)
+        if not payload.endswith(b"\n"):
+            buffer.write(b"\n")
+
+    _write_object(b"1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n")
+    _write_object(b"2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj\n")
+    _write_object(
+        b"3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>endobj\n"
+    )
+    stream_header = f"4 0 obj<< /Length {len(stream_content)} >>stream\n".encode("ascii")
+    _write_object(stream_header + stream_content + b"\nendstream\nendobj\n")
+    _write_object(b"5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n")
+
+    xref_offset = buffer.tell()
+    buffer.write(f"xref\n0 {len(offsets) + 1}\n".encode("ascii"))
+    buffer.write(b"0000000000 65535 f \n")
+    for offset in offsets:
+        buffer.write(f"{offset:010d} 00000 n \n".encode("ascii"))
+    buffer.write(f"trailer<< /Size {len(offsets) + 1} /Root 1 0 R >>\n".encode("ascii"))
+    buffer.write(b"startxref\n")
+    buffer.write(f"{xref_offset}\n".encode("ascii"))
+    buffer.write(b"%%EOF\n")
+    return buffer.getvalue()
+
+
 def test_normalize_label_strips_whitespace() -> None:
     assert normalize_label(" 제 조 자 ") == "제조자"
 
 
 def test_extract_project_metadata_reads_table() -> None:
     metadata = extract_project_metadata(_build_sample_agreement())
+    assert metadata == {
+        "exam_number": "GS-B-12-3456",
+        "company_name": "Acme Corp",
+        "product_name": "Wonder Widget 1.0",
+    }
+
+
+def test_extract_project_metadata_reads_pdf() -> None:
+    metadata = extract_project_metadata(_build_sample_pdf_agreement(), file_extension=".pdf")
     assert metadata == {
         "exam_number": "GS-B-12-3456",
         "company_name": "Acme Corp",

--- a/frontend/src/components/ProjectCreationModal.tsx
+++ b/frontend/src/components/ProjectCreationModal.tsx
@@ -14,7 +14,7 @@ interface ProjectCreationModalProps {
   backendUrl?: string
 }
 
-const DOCX_ONLY: FileType[] = ['docx']
+const AGREEMENT_FILE_TYPES: FileType[] = ['docx', 'pdf']
 
 export function ProjectCreationModal({
   open,
@@ -45,7 +45,7 @@ export function ProjectCreationModal({
     setSubmitError(null)
 
     if (files.length === 0) {
-      setFormError('최소 한 개의 PDF 파일을 업로드해주세요.')
+      setFormError('최소 한 개의 DOCX 또는 PDF 파일을 업로드해주세요.')
       return
     }
 
@@ -98,7 +98,7 @@ export function ProjectCreationModal({
       open={open}
       onClose={isSubmitting ? () => {} : onClose}
       title="새 프로젝트 생성"
-      description="PDF를 업로드하면 'GS-X-X-XXXX' 폴더와 필수 하위 폴더가 자동으로 만들어집니다."
+      description="DOCX 또는 PDF를 업로드하면 'GS-X-X-XXXX' 폴더와 필수 하위 폴더가 자동으로 만들어집니다."
     >
       <form className="modal__form" onSubmit={handleSubmit} aria-busy={isSubmitting}>
         <div className="modal__body">
@@ -106,7 +106,7 @@ export function ProjectCreationModal({
             업로드한 파일은 생성되는 프로젝트의 ‘0. 사전 자료’ 폴더에 저장됩니다.
           </p>
 
-          <FileUploader allowedTypes={DOCX_ONLY} files={files} onChange={setFiles} />
+          <FileUploader allowedTypes={AGREEMENT_FILE_TYPES} files={files} onChange={setFiles} />
 
           {formError && (
             <p className="modal__error" role="alert">


### PR DESCRIPTION
## Summary
- extend the agreement metadata extractor to handle both DOCX and PDF inputs while keeping validation for required fields
- allow the Google Drive project creation workflow to accept PDF uploads, preserve appropriate defaults, and surface clearer errors
- expose DOCX/PDF upload support in the project creation modal and cover PDF parsing with a unit test alongside the new dependency

## Testing
- pytest backend/tests/test_google_drive_metadata.py *(skipped: could not import 'pypdf' in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5cc4a1e48330835aff75b0748e96)