### PR TITLE
Add delete control for scenario subcategories in testcase workflow

### DIFF
--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
@@ -292,6 +292,23 @@
   background: #e0f2fe;
 }
 
+.testcase-workflow__danger {
+  background: transparent;
+  color: #b42318;
+  border: 1px solid #fca5a5;
+}
+
+.testcase-workflow__danger:hover:not(:disabled),
+.testcase-workflow__danger:focus-visible:not(:disabled) {
+  background: #fee2e2;
+}
+
+.testcase-workflow__danger:disabled {
+  background: transparent;
+  color: #fca5a5;
+  border-color: #fecaca;
+}
+
 .testcase-workflow__scenario-list {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
@@ -678,6 +678,29 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
     })
   }, [])
 
+  const handleRemoveGroup = useCallback((groupIndex: number) => {
+    if (groupIndex < 0) {
+      return
+    }
+
+    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      const confirmed = window.confirm(
+        '이 소분류를 삭제할까요? 생성된 시나리오와 첨부한 파일이 모두 사라집니다.',
+      )
+      if (!confirmed) {
+        return
+      }
+    }
+
+    setGroups((prev) => {
+      if (groupIndex < 0 || groupIndex >= prev.length) {
+        return prev
+      }
+
+      return prev.filter((_, index) => index !== groupIndex)
+    })
+  }, [])
+
   const canProceedToReview = useMemo(
     () => groups.length > 0 && groups.every((group) => group.scenarios.length >= 1),
     [groups],
@@ -937,6 +960,13 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
                         수정
                       </button>
                     )}
+                    <button
+                      type="button"
+                      className="testcase-workflow__danger testcase-workflow__button"
+                      onClick={() => handleRemoveGroup(index)}
+                    >
+                      소분류 삭제
+                    </button>
                   </div>
                 </header>
 


### PR DESCRIPTION
## Summary
- allow scenario groups to be removed during the testcase workflow's scenario design step
- add a dedicated destructive button style for the new delete action

## Testing
- npm run test -- --watch=false *(fails: vitest not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5ced48a883309b6ba2ef55b4d13e)