### PR TITLE
Fix polished text editing state regression on Windows

### DIFF
--- a/frontend/src/components/DefectReportWorkflow.tsx
+++ b/frontend/src/components/DefectReportWorkflow.tsx
@@ -240,7 +240,13 @@ export function DefectReportWorkflow({
       updatePolished(defectIndex, value)
       setDefectItems((prev) =>
         prev.map((item) =>
-          item.entry.index === defectIndex ? { ...item, isCollapsed: false } : item,
+          item.entry.index === defectIndex
+            ? {
+                ...item,
+                entry: { ...item.entry, polishedText: value },
+                isCollapsed: false,
+              }
+            : item,
         ),
       )
     },


### PR DESCRIPTION
## Summary
- keep defect cards in sync with polished text edits so the textarea value updates immediately
- prevent refined sentence editing glitches observed on Windows input methods

## Testing
- npm run test -- --run *(fails: vitest not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5d1ea73083308ffda4c98fca2db5)