### PR TITLE
Reposition project sidebar toggle within page layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1586,13 +1586,32 @@
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+  position: absolute;
+  top: 50%;
+  z-index: 3;
+  --project-management-sidebar-toggle-x: 0;
+  --project-management-sidebar-toggle-y: -50%;
+  transition:
+    left 0.3s ease,
+    transform 0.3s ease,
+    background 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease,
     border-color 0.2s ease;
+  transform: translate(
+    var(--project-management-sidebar-toggle-x),
+    var(--project-management-sidebar-toggle-y)
+  );
 }
 
 .project-management-sidebar-toggle:hover,
 .project-management-sidebar-toggle:focus-visible {
-  transform: translateY(-1px);
+  transform:
+    translate(
+      var(--project-management-sidebar-toggle-x),
+      var(--project-management-sidebar-toggle-y)
+    )
+    translateY(-1px);
   background: rgba(30, 41, 59, 0.9);
   color: #f8fafc;
   box-shadow: 0 20px 36px rgba(15, 23, 42, 0.28);
@@ -1602,6 +1621,16 @@
 .project-management-sidebar-toggle:focus-visible {
   outline: 3px solid rgba(59, 130, 246, 0.45);
   outline-offset: 2px;
+}
+
+.project-management-page--sidebar-open .project-management-sidebar-toggle {
+  left: var(--project-management-sidebar-width);
+  --project-management-sidebar-toggle-x: 50%;
+}
+
+.project-management-page--sidebar-collapsed .project-management-sidebar-toggle {
+  left: 0.75rem;
+  --project-management-sidebar-toggle-x: 0;
 }
 
 .project-management-sidebar-toggle__icon {

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -9,7 +9,6 @@ import { Modal } from '../components/Modal'
 import { useBackgroundTasks } from '../app/background/BackgroundTaskContext'
 import { getBackendUrl } from '../config'
 import { navigate } from '../navigation'
-import { useAppShellHeader } from '../app/components/AppShellHeaderContext'
 
 type MenuItemId =
   | 'configuration-images'
@@ -325,8 +324,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const { startTask } = useBackgroundTasks()
   const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const isMountedRef = useRef(true)
-  const { setLeadingAction } = useAppShellHeader()
-
   const menuById = useMemo(() => {
     return MENU_ITEMS.reduce((acc, item) => {
       acc[item.id] = item
@@ -1266,8 +1263,22 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   }, [])
 
   const sidebarToggleLabel = isSidebarOpen ? '사이드바 접기' : '사이드바 펼치기'
-  const sidebarToggleAction = useMemo(
-    () => (
+  const pageClassName = [
+    'project-management-page',
+    isSidebarOpen ? 'project-management-page--sidebar-open' : 'project-management-page--sidebar-collapsed',
+    isTestcaseWorkflow ? 'project-management-page--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const contentClassName = [
+    'project-management-content',
+    isTestcaseWorkflow ? 'project-management-content--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={pageClassName}>
       <button
         type="button"
         className="project-management-sidebar-toggle"
@@ -1307,33 +1318,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         </span>
         <span className="project-management-sr-only">{sidebarToggleLabel}</span>
       </button>
-    ),
-    [handleToggleSidebar, isSidebarOpen, sidebarToggleLabel],
-  )
-
-  useEffect(() => {
-    setLeadingAction(sidebarToggleAction)
-
-    return () => {
-      setLeadingAction(null)
-    }
-  }, [setLeadingAction, sidebarToggleAction])
-  const pageClassName = [
-    'project-management-page',
-    isSidebarOpen ? 'project-management-page--sidebar-open' : 'project-management-page--sidebar-collapsed',
-    isTestcaseWorkflow ? 'project-management-page--preview' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-  const contentClassName = [
-    'project-management-content',
-    isTestcaseWorkflow ? 'project-management-content--preview' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  return (
-    <div className={pageClassName}>
       <aside
         id="project-management-sidebar"
         className="project-management-sidebar"


### PR DESCRIPTION
## Summary
- render the project management sidebar toggle within the page so it stays attached to the sidebar
- adjust sidebar toggle positioning styles so the control rides the sidebar in both open and collapsed states

## Testing
- npm --prefix frontend run lint *(fails: missing @eslint/js package in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5c1451588330a2e99d4126e87c55)