### PR TITLE
Add bulk scenario generation button to testcase workflow

### DIFF
--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.css
@@ -27,6 +27,16 @@
   line-height: 1.5;
 }
 
+.testcase-workflow__bulk-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.testcase-workflow__bulk-actions .testcase-workflow__button {
+  min-width: 180px;
+}
+
 .testcase-workflow__overview {
   margin: 0 0 1.25rem;
   padding: 1rem;

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
@@ -101,6 +101,7 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
     null,
   )
   const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [isGeneratingAll, setIsGeneratingAll] = useState(false)
   const idRef = useRef(0)
   const storageKey = useMemo(() => `tta:testcase-workflow:${projectId}`, [projectId])
 
@@ -416,6 +417,22 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
     },
     [backendUrl, groups, projectId, projectOverview],
   )
+
+  const handleGenerateAllScenarios = useCallback(async () => {
+    if (groups.length === 0) {
+      return
+    }
+
+    setIsGeneratingAll(true)
+    try {
+      for (let index = 0; index < groups.length; index += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await handleGenerateScenarios(index)
+      }
+    } finally {
+      setIsGeneratingAll(false)
+    }
+  }, [groups, handleGenerateScenarios])
 
   const handleUpdateScenarioField = useCallback((groupIndex: number, scenarioId: string, key: 'scenario' | 'input' | 'expected', value: string) => {
     setGroups((prev) => {
@@ -919,6 +936,16 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
               <p className="testcase-workflow__overview-description">{projectOverview}</p>
             </aside>
           )}
+          <div className="testcase-workflow__bulk-actions">
+            <button
+              type="button"
+              className="testcase-workflow__button"
+              onClick={handleGenerateAllScenarios}
+              disabled={isGeneratingAll || groups.length === 0}
+            >
+              {isGeneratingAll ? '전체 생성 중…' : '전체 시나리오 생성'}
+            </button>
+          </div>
           <div className="testcase-workflow__feature-list">
             {groups.map((group, index) => (
               <article
@@ -1008,7 +1035,7 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
                               type="button"
                               className="testcase-workflow__button"
                               onClick={() => handleGenerateScenarios(index)}
-                              disabled={group.status === 'loading'}
+                              disabled={group.status === 'loading' || isGeneratingAll}
                             >
                               {group.status === 'loading' ? '생성 중…' : '시나리오 생성'}
                             </button>


### PR DESCRIPTION
## Summary
- add a bulk scenario generation button to the top of the scenarios step
- disable individual scenario generation buttons while a bulk run is in progress
- style the new bulk action container for consistent layout

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d6ae7d31083309ec8664702795423)