### PR TITLE
Ensure defect drawing nodes precede legacy drawings

### DIFF
--- a/backend/app/services/excel_templates.py
+++ b/backend/app/services/excel_templates.py
@@ -1409,7 +1409,29 @@ def _inject_defect_images(
     # Add drawing reference to sheet xml
     drawing_elem = ET.Element(f"{{{_SPREADSHEET_NS}}}drawing")
     drawing_elem.set(f"{{{_REL_NS}}}id", sheet_rel_id)
-    sheet_root.append(drawing_elem)
+
+    children = list(sheet_root)
+
+    def _local_name(tag: str) -> str:
+        return tag.split("}", 1)[-1] if "}" in tag else tag
+
+    insert_index = len(children)
+    for index, child in enumerate(children):
+        if _local_name(child.tag) == "legacyDrawing":
+            insert_index = index
+            break
+    else:
+        last_drawing_index: int | None = None
+        for index, child in enumerate(children):
+            if _local_name(child.tag) == "drawing":
+                last_drawing_index = index + 1
+        if last_drawing_index is not None:
+            insert_index = last_drawing_index
+
+    if insert_index >= len(children):
+        sheet_root.append(drawing_elem)
+    else:
+        sheet_root.insert(insert_index, drawing_elem)
     final_sheet = ET.tostring(sheet_root, encoding="utf-8", xml_declaration=True)
 
     source_buffer.seek(0)

--- a/backend/app/services/excel_templates/defect_report.py
+++ b/backend/app/services/excel_templates/defect_report.py
@@ -344,7 +344,29 @@ def _inject_defect_images(
 
     drawing_elem = ET.Element(f"{{{SPREADSHEET_NS}}}drawing")
     drawing_elem.set(f"{{{REL_NS}}}id", sheet_rel_id)
-    sheet_root.append(drawing_elem)
+
+    children = list(sheet_root)
+
+    def _local_name(tag: str) -> str:
+        return tag.split("}", 1)[-1] if "}" in tag else tag
+
+    insert_index = len(children)
+    for index, child in enumerate(children):
+        if _local_name(child.tag) == "legacyDrawing":
+            insert_index = index
+            break
+    else:
+        last_drawing_index: int | None = None
+        for index, child in enumerate(children):
+            if _local_name(child.tag) == "drawing":
+                last_drawing_index = index + 1
+        if last_drawing_index is not None:
+            insert_index = last_drawing_index
+
+    if insert_index >= len(children):
+        sheet_root.append(drawing_elem)
+    else:
+        sheet_root.insert(insert_index, drawing_elem)
     final_sheet = ET.tostring(sheet_root, encoding="utf-8", xml_declaration=True)
 
     source_buffer.seek(0)

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import importlib.util
 import io
 import sys
 import zipfile
@@ -26,15 +27,93 @@ from app.services.excel_templates import (
     populate_security_report,
     populate_testcase_list,
 )
+from app.services.excel_templates.defect_report import (
+    DefectReportImage as modern_DefectReportImage,
+    _inject_defect_images as modern_inject_defect_images,
+)
 from app.services.excel_templates.security_report import _extract_existing_rows
 
 _SPREADSHEET_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+_RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+_DUMMY_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACklEQVR42mP8/5+hHgAHggJ/P0BkhQAAAABJRU5ErkJggg=="
+)
+import app.services.excel_templates.utils as modern_utils
+sys.modules.setdefault("app.services.utils", modern_utils)
+_LEGACY_SPEC = importlib.util.spec_from_file_location(
+    "app.services._legacy_excel_templates",
+    BACKEND_ROOT / "app/services/excel_templates.py",
+)
+assert _LEGACY_SPEC and _LEGACY_SPEC.loader is not None
+legacy_module = importlib.util.module_from_spec(_LEGACY_SPEC)
+sys.modules[_LEGACY_SPEC.name] = legacy_module
+_LEGACY_SPEC.loader.exec_module(legacy_module)
+legacy_inject_defect_images = legacy_module._inject_defect_images
+legacy_DefectReportImage = legacy_module.DefectReportImage
 
 
 def _load_sheet(workbook_bytes: bytes) -> ET.Element:
     with zipfile.ZipFile(io.BytesIO(workbook_bytes), "r") as zf:
         data = zf.read("xl/worksheets/sheet1.xml")
     return ET.fromstring(data)
+
+
+def _build_test_workbook(*, include_drawing: bool, include_legacy: bool) -> tuple[bytes, bytes]:
+    page_margins = '<pageMargins left="0" right="0" top="0" bottom="0"/>'
+    sheet_parts = [
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>",
+        "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"",
+        "           xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">",
+        "  <sheetData>",
+        "    <row r=\"6\" ht=\"15\"/>",
+        "  </sheetData>",
+        f"  {page_margins}",
+    ]
+
+    rel_entries: list[str] = []
+
+    if include_drawing:
+        sheet_parts.append('  <drawing r:id="rId1"/>')
+        rel_entries.append(
+            '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" '
+            'Target="../drawings/drawing1.xml"/>'
+        )
+
+    if include_legacy:
+        legacy_rel_id = "rId2" if include_drawing else "rId1"
+        sheet_parts.append(f'  <legacyDrawing r:id="{legacy_rel_id}"/>')
+        rel_entries.append(
+            f'<Relationship Id="{legacy_rel_id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing" '
+            'Target="../drawings/vmlDrawing1.vml"/>'
+        )
+
+    sheet_parts.append("</worksheet>")
+    sheet_xml = "\n".join(sheet_parts)
+
+    rels_lines = [
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>",
+        f"<Relationships xmlns=\"{_RELATIONSHIPS_NS}\">",
+        *rel_entries,
+        "</Relationships>",
+    ]
+    sheet_rels_xml = "\n".join(rels_lines)
+
+    content_types_xml = """<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">
+  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>
+  <Default Extension=\"xml\" ContentType=\"application/xml\"/>
+  <Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>
+</Types>
+"""
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("[Content_Types].xml", content_types_xml)
+        zf.writestr("xl/worksheets/sheet1.xml", sheet_xml)
+        zf.writestr("xl/worksheets/_rels/sheet1.xml.rels", sheet_rels_xml)
+
+    return buffer.getvalue(), sheet_xml.encode("utf-8")
 
 
 def _cell_text(root: ET.Element, ref: str) -> str | None:
@@ -336,3 +415,63 @@ def test_populate_defect_report_accepts_spaced_headers() -> None:
     assert _cell_text(root, "F6") == "보안성"
     assert _cell_text(root, "G6") == "상세 설명"
     assert _cell_text(root, "J6") == "비고 메모"
+
+
+@pytest.mark.parametrize(
+    "inject_fn,image_cls",
+    [
+        (modern_inject_defect_images, modern_DefectReportImage),
+        (legacy_inject_defect_images, legacy_DefectReportImage),
+    ],
+)
+def test_inject_defect_images_inserts_before_legacy(
+    inject_fn, image_cls
+) -> None:
+    workbook_bytes, sheet_bytes = _build_test_workbook(
+        include_drawing=False, include_legacy=True
+    )
+    images_map = {1: [image_cls(file_name="image.png", content=_DUMMY_PNG)]}
+
+    result = inject_fn(
+        workbook_bytes,
+        sheet_bytes,
+        row_positions={1: 6},
+        images_map=images_map,
+        column_letter="J",
+    )
+
+    root = _load_sheet(result)
+    child_tags = [child.tag.split("}", 1)[-1] for child in list(root)]
+    assert child_tags == ["sheetData", "pageMargins", "drawing", "legacyDrawing"]
+
+
+@pytest.mark.parametrize(
+    "inject_fn,image_cls",
+    [
+        (modern_inject_defect_images, modern_DefectReportImage),
+        (legacy_inject_defect_images, legacy_DefectReportImage),
+    ],
+)
+def test_inject_defect_images_preserves_existing_drawing_order(
+    inject_fn, image_cls
+) -> None:
+    workbook_bytes, sheet_bytes = _build_test_workbook(
+        include_drawing=True, include_legacy=True
+    )
+    images_map = {1: [image_cls(file_name="image.png", content=_DUMMY_PNG)]}
+
+    result = inject_fn(
+        workbook_bytes,
+        sheet_bytes,
+        row_positions={1: 6},
+        images_map=images_map,
+        column_letter="J",
+    )
+
+    root = _load_sheet(result)
+    child_tags = [child.tag.split("}", 1)[-1] for child in list(root)]
+    assert child_tags == ["sheetData", "pageMargins", "drawing", "drawing", "legacyDrawing"]
+
+    drawings = [child for child in root if child.tag.split("}", 1)[-1] == "drawing"]
+    assert len(drawings) == 2
+    assert all(drawing.get(f"{{{_REL_NS}}}id") for drawing in drawings)


### PR DESCRIPTION
## Summary
- update both defect report drawing injectors to insert new drawing elements before legacyDrawing nodes or alongside existing drawing nodes
- add regression helpers that load the legacy excel_templates module for compatibility checks
- extend excel population tests to cover templates with only legacyDrawing or with both drawing types, asserting child element order

## Testing
- pytest backend/tests/test_excel_population.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d6afaaeb883308abc555d980abb9b)