### PR TITLE
Update project folder naming for Drive projects

### DIFF
--- a/backend/app/services/google_drive/metadata.py
+++ b/backend/app/services/google_drive/metadata.py
@@ -57,7 +57,8 @@ def build_project_folder_name(metadata: Dict[str, str]) -> str:
     exam_number = metadata.get("exam_number", "").strip()
     company_name = metadata.get("company_name", "").strip()
     product_name = metadata.get("product_name", "").strip()
-    return f"[{exam_number}] {company_name} - {product_name}"
+    parts = [part for part in (exam_number, company_name, product_name) if part]
+    return " ".join(parts)
 
 
 def _extract_project_metadata_from_docx(file_bytes: bytes) -> Dict[str, str]:

--- a/backend/tests/test_google_drive_metadata.py
+++ b/backend/tests/test_google_drive_metadata.py
@@ -181,4 +181,4 @@ def test_build_project_folder_name_formats_metadata() -> None:
         "company_name": "Acme Corp",
         "product_name": "Wonder Widget 1.0",
     }
-    assert build_project_folder_name(metadata) == "[GS-B-12-3456] Acme Corp - Wonder Widget 1.0"
+    assert build_project_folder_name(metadata) == "GS-B-12-3456 Acme Corp Wonder Widget 1.0"


### PR DESCRIPTION
## Summary
- adjust Drive project folder naming to concatenate the exam number, company name, and product name with spaces
- update the metadata unit test expectation to match the new naming format

## Testing
- pytest backend/tests/test_google_drive_metadata.py::test_build_project_folder_name_formats_metadata


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d72a8692883309c2630d1b2548c74)