### PR TITLE
Sanitize Excel exports to filter invalid XML characters

### DIFF
--- a/backend/app/services/excel_templates.py
+++ b/backend/app/services/excel_templates.py
@@ -299,18 +299,33 @@ def _clear_cell(cell: ET.Element) -> None:
         cell.remove(child)
 
 
+def _sanitize_xml_text(value: str) -> str:
+    def is_allowed(codepoint: int) -> bool:
+        return (
+            codepoint in {0x9, 0xA, 0xD}
+            or 0x20 <= codepoint <= 0xD7FF
+            or 0xE000 <= codepoint <= 0xFFFD
+            or 0x10000 <= codepoint <= 0x10FFFF
+        )
+
+    return "".join(ch for ch in value if is_allowed(ord(ch)))
+
+
 def _set_cell_text(cell: ET.Element, value: str) -> None:
     _clear_cell(cell)
-    cleaned = value.strip()
+    if value is None:
+        value = ""
+    sanitized_value = _sanitize_xml_text(value)
+    cleaned = sanitized_value.strip()
     if not cleaned:
         return
 
     cell.set("t", "inlineStr")
     is_elem = ET.SubElement(cell, f"{{{_SPREADSHEET_NS}}}is")
     text_elem = ET.SubElement(is_elem, f"{{{_SPREADSHEET_NS}}}t")
-    if cleaned != value or "\n" in value:
+    if cleaned != sanitized_value or "\n" in sanitized_value:
         text_elem.set(f"{{{_XML_NS}}}space", "preserve")
-        text_elem.text = value
+        text_elem.text = sanitized_value
     else:
         text_elem.text = cleaned
 

--- a/backend/app/services/excel_templates/workbook.py
+++ b/backend/app/services/excel_templates/workbook.py
@@ -148,18 +148,33 @@ def _clear_cell(cell: ET.Element) -> None:
         cell.remove(child)
 
 
+def _sanitize_xml_text(value: str) -> str:
+    def is_allowed(codepoint: int) -> bool:
+        return (
+            codepoint in {0x9, 0xA, 0xD}
+            or 0x20 <= codepoint <= 0xD7FF
+            or 0xE000 <= codepoint <= 0xFFFD
+            or 0x10000 <= codepoint <= 0x10FFFF
+        )
+
+    return "".join(ch for ch in value if is_allowed(ord(ch)))
+
+
 def set_cell_text(cell: ET.Element, value: str) -> None:
     _clear_cell(cell)
-    cleaned = value.strip()
+    if value is None:
+        value = ""
+    sanitized_value = _sanitize_xml_text(value)
+    cleaned = sanitized_value.strip()
     if not cleaned:
         return
 
     cell.set("t", "inlineStr")
     is_elem = ET.SubElement(cell, f"{{{SPREADSHEET_NS}}}is")
     text_elem = ET.SubElement(is_elem, f"{{{SPREADSHEET_NS}}}t")
-    if cleaned != value or "\n" in value:
+    if cleaned != sanitized_value or "\n" in sanitized_value:
         text_elem.set(f"{{{XML_NS}}}space", "preserve")
-        text_elem.text = value
+        text_elem.text = sanitized_value
     else:
         text_elem.text = cleaned
 

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -181,6 +181,35 @@ def test_populate_feature_list_sets_project_overview() -> None:
     assert _cell_text(root, ref) == overview_text
 
 
+def test_populate_feature_list_sanitizes_invalid_xml_characters() -> None:
+    template_path = Path("backend/template/가.계획/GS-B-XX-XXXX 기능리스트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    invalid_char = "\u000b"
+    csv_text = "\n".join(
+        [
+            "|".join(FEATURE_LIST_EXPECTED_HEADERS),
+            f"대1|중1|소1|기능{invalid_char}상세",
+        ]
+    )
+
+    overview_text = f"이 프로젝트는{invalid_char} 소개 문장"
+    updated = populate_feature_list(
+        template_bytes,
+        csv_text,
+        project_overview=overview_text,
+    )
+
+    root = _load_sheet(updated)
+
+    assert _cell_text(root, "D8") == "기능상세"
+
+    ref, value = extract_feature_list_overview(updated)
+    assert ref is not None
+    assert value == "이 프로젝트는 소개 문장"
+    assert _cell_text(root, ref) == "이 프로젝트는 소개 문장"
+
+
 def test_populate_testcase_list_maps_columns() -> None:
     template_path = Path("backend/template/나.설계/GS-B-XX-XXXX 테스트케이스.xlsx")
     template_bytes = template_path.read_bytes()


### PR DESCRIPTION
## Summary
- filter out characters that are invalid in XML 1.0 before writing inline strings
- apply the same sanitisation when legacy helpers populate project overview text
- add a regression test that ensures invalid control codes no longer corrupt the generated feature list sheet

## Testing
- pytest backend/tests/test_excel_population.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6568d6508330a8078a28b096bb75)