### PR TITLE
Sanitize worksheet text for feature list population

### DIFF
--- a/backend/app/services/excel_templates.py
+++ b/backend/app/services/excel_templates.py
@@ -733,19 +733,7 @@ class WorksheetPopulator:
         return new_cell
 
     def _set_cell_value(self, cell: ET.Element, value: str) -> None:
-        self._clear_cell(cell)
-        cleaned = value.strip()
-        if not cleaned:
-            return
-
-        cell.set("t", "inlineStr")
-        is_elem = ET.SubElement(cell, self._tag("is"))
-        t_elem = ET.SubElement(is_elem, self._tag("t"))
-        if cleaned != value or "\n" in value:
-            t_elem.set(f"{{{_XML_NS}}}space", "preserve")
-            t_elem.text = value
-        else:
-            t_elem.text = cleaned
+        _set_cell_text(cell, value)
 
     def populate(self, records: Sequence[Dict[str, str]]) -> None:
         # 우선 기존 데이터를 비웁니다.

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -210,6 +210,39 @@ def test_populate_feature_list_sanitizes_invalid_xml_characters() -> None:
     assert _cell_text(root, ref) == "이 프로젝트는 소개 문장"
 
 
+def test_legacy_populate_feature_list_sanitizes_invalid_xml_characters() -> None:
+    template_path = Path("backend/template/가.계획/GS-B-XX-XXXX 기능리스트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    invalid_char = "\u000b"
+    csv_text = "\n".join(
+        [
+            "|".join(FEATURE_LIST_EXPECTED_HEADERS),
+            f"대1|중1|소1|기능{invalid_char}상세",
+        ]
+    )
+
+    overview_text = f"이 프로젝트는{invalid_char} 소개 문장"
+    updated = legacy_module.populate_feature_list(
+        template_bytes,
+        csv_text,
+        project_overview=overview_text,
+    )
+
+    with zipfile.ZipFile(io.BytesIO(updated), "r") as zf:
+        sheet_bytes = zf.read("xl/worksheets/sheet1.xml")
+
+    assert invalid_char.encode("utf-8") not in sheet_bytes
+    root = ET.fromstring(sheet_bytes)
+
+    assert _cell_text(root, "D8") == "기능상세"
+
+    ref, value = extract_feature_list_overview(updated)
+    assert ref is not None
+    assert value == "이 프로젝트는 소개 문장"
+    assert _cell_text(root, ref) == "이 프로젝트는 소개 문장"
+
+
 def test_populate_testcase_list_maps_columns() -> None:
     template_path = Path("backend/template/나.설계/GS-B-XX-XXXX 테스트케이스.xlsx")
     template_bytes = template_path.read_bytes()


### PR DESCRIPTION
## Summary
- reuse the shared inline-string helper when populating worksheet cells so all strings are XML-sanitized
- add a regression test covering the legacy feature list populator with invalid control characters

## Testing
- pytest backend/tests/test_excel_population.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6ecacba08330b7b2e15c45b3c1ef)