### PR TITLE
Avoid injecting worksheet dimensions when absent

### DIFF
--- a/backend/app/services/excel_templates/feature_list.py
+++ b/backend/app/services/excel_templates/feature_list.py
@@ -312,47 +312,36 @@ def _apply_project_overview_to_sheet(sheet_bytes: bytes, cell_ref: str, value: s
     set_cell_text(cell, value)
 
     dimension = root.find("s:dimension", ns)
-    if dimension is None:
-        dimension_tag = f"{{{SPREADSHEET_NS}}}dimension"
-        dimension = ET.Element(dimension_tag)
-        inserted = False
-        for idx, child in enumerate(list(root)):
-            if child.tag in {dimension_tag, f"{{{SPREADSHEET_NS}}}sheetData"}:
-                root.insert(idx, dimension)
-                inserted = True
-                break
-        if not inserted:
-            root.insert(0, dimension)
+    if dimension is not None:
+        ref = (dimension.get("ref") or "").strip()
+        current_col_index = column_to_index(column)
+        if ref:
+            start_col, start_row, end_col, end_row = parse_dimension(ref)
+            start_col_index = column_to_index(start_col)
+            end_col_index = column_to_index(end_col)
+        else:
+            start_row = end_row = row_index
+            start_col_index = end_col_index = current_col_index
 
-    ref = (dimension.get("ref") or "").strip()
-    current_col_index = column_to_index(column)
-    if ref:
-        start_col, start_row, end_col, end_row = parse_dimension(ref)
-        start_col_index = column_to_index(start_col)
-        end_col_index = column_to_index(end_col)
-    else:
-        start_row = end_row = row_index
-        start_col_index = end_col_index = current_col_index
+        updated = False
+        if row_index < start_row:
+            start_row = row_index
+            updated = True
+        if row_index > end_row:
+            end_row = row_index
+            updated = True
+        if current_col_index < start_col_index:
+            start_col_index = current_col_index
+            updated = True
+        if current_col_index > end_col_index:
+            end_col_index = current_col_index
+            updated = True
 
-    updated = False
-    if row_index < start_row:
-        start_row = row_index
-        updated = True
-    if row_index > end_row:
-        end_row = row_index
-        updated = True
-    if current_col_index < start_col_index:
-        start_col_index = current_col_index
-        updated = True
-    if current_col_index > end_col_index:
-        end_col_index = current_col_index
-        updated = True
-
-    if updated or not ref:
-        dimension.set(
-            "ref",
-            f"{index_to_column(start_col_index)}{start_row}:{index_to_column(end_col_index)}{end_row}",
-        )
+        if updated or not ref:
+            dimension.set(
+                "ref",
+                f"{index_to_column(start_col_index)}{start_row}:{index_to_column(end_col_index)}{end_row}",
+            )
 
     return ET.tostring(root, encoding="utf-8", xml_declaration=True)
 

--- a/backend/app/services/excel_templates/workbook.py
+++ b/backend/app/services/excel_templates/workbook.py
@@ -238,19 +238,6 @@ class WorksheetPopulator:
             if not ref:
                 raise ValueError("워크시트 범위 정보를 찾을 수 없습니다.")
 
-            dimension_tag = f"{{{SPREADSHEET_NS}}}dimension"
-            if self._dimension is None:
-                self._dimension = ET.Element(dimension_tag)
-                inserted = False
-                for idx, child in enumerate(list(self._root)):
-                    if child.tag in {dimension_tag, f"{{{SPREADSHEET_NS}}}sheetData"}:
-                        self._root.insert(idx, self._dimension)
-                        inserted = True
-                        break
-                if not inserted:
-                    self._root.insert(0, self._dimension)
-            self._dimension.set("ref", ref)
-
         (
             self._dimension_start_col,
             self._dimension_start_row,
@@ -417,10 +404,12 @@ class WorksheetPopulator:
             last_row = self._start_row
         if last_row > self._dimension_end_row:
             self._dimension_end_row = last_row
-        self._dimension.set(
-            "ref",
-            f"{self._dimension_start_col}{self._dimension_start_row}:{self._dimension_end_col}{self._dimension_end_row}",
-        )
+
+        if self._dimension is not None:
+            self._dimension.set(
+                "ref",
+                f"{self._dimension_start_col}{self._dimension_start_row}:{self._dimension_end_col}{self._dimension_end_row}",
+            )
 
     def _merge_tag(self, name: str) -> str:
         return f"{{{SPREADSHEET_NS}}}{name}"


### PR DESCRIPTION
## Summary
- stop `_apply_project_overview_to_sheet` from creating a `<dimension>` element when worksheets omit the tag
- update the existing dimension range only when the element is already present

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691011a7524483309ed6dcb2627aea53)