### PR TITLE
Ensure dimension added when inferred

### DIFF
--- a/backend/app/services/excel_templates/workbook.py
+++ b/backend/app/services/excel_templates/workbook.py
@@ -229,6 +229,7 @@ class WorksheetPopulator:
         }
 
         self._dimension = self._root.find("s:dimension", self._ns)
+        self._dimension_was_missing = self._dimension is None
         ref = ""
         if self._dimension is not None:
             ref = (self._dimension.get("ref") or "").strip()
@@ -410,6 +411,7 @@ class WorksheetPopulator:
                 "ref",
                 f"{self._dimension_start_col}{self._dimension_start_row}:{self._dimension_end_col}{self._dimension_end_row}",
             )
+        self._dimension_was_missing = self._dimension is None and self._dimension_was_missing
 
     def _merge_tag(self, name: str) -> str:
         return f"{{{SPREADSHEET_NS}}}{name}"
@@ -533,4 +535,24 @@ class WorksheetPopulator:
         )
 
     def to_bytes(self) -> bytes:
+        ref = (
+            f"{self._dimension_start_col}{self._dimension_start_row}:"
+            f"{self._dimension_end_col}{self._dimension_end_row}"
+        )
+
+        if self._dimension is not None:
+            self._dimension.set("ref", ref)
+        elif self._dimension_was_missing:
+            dimension_elem = ET.Element(self._tag("dimension"), {"ref": ref})
+            sheet_data_tag = self._tag("sheetData")
+            inserted = False
+            for index, child in enumerate(list(self._root)):
+                if child.tag == sheet_data_tag:
+                    self._root.insert(index, dimension_elem)
+                    inserted = True
+                    break
+            if not inserted:
+                self._root.insert(0, dimension_elem)
+            self._dimension = dimension_elem
+            self._dimension_was_missing = False
         return ET.tostring(self._root, encoding="utf-8", xml_declaration=True)

--- a/backend/tests/test_excel_testcases.py
+++ b/backend/tests/test_excel_testcases.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import re
 import sys
 import zipfile
 from pathlib import Path
@@ -13,6 +14,7 @@ if str(BACKEND_ROOT) not in sys.path:
 
 from app.services.excel_templates import testcases
 from app.services.excel_templates.models import SPREADSHEET_NS
+from app.services.excel_templates.workbook import replace_sheet_bytes
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "data" / "excel_templates"
 TEMPLATE_PATH = BACKEND_ROOT / "template" / "나.설계" / "GS-B-XX-XXXX 테스트케이스.xlsx"
@@ -56,3 +58,35 @@ def test_populate_testcase_list_matches_fixture() -> None:
     assert cell_text("A", 7) == ""
     assert cell_text("B", 6) == "중분류B"
     assert cell_text("B", 7) == ""
+
+
+def test_populate_testcase_list_recreates_missing_dimension() -> None:
+    template_bytes = TEMPLATE_PATH.read_bytes()
+    csv_text = (FIXTURE_DIR / "testcases.csv").read_text(encoding="utf-8")
+
+    with zipfile.ZipFile(io.BytesIO(template_bytes), "r") as archive:
+        sheet_xml = archive.read("xl/worksheets/sheet1.xml")
+
+    root = ET.fromstring(sheet_xml)
+    ns = {"s": SPREADSHEET_NS}
+    dimension = root.find("s:dimension", ns)
+    if dimension is not None:
+        root.remove(dimension)
+
+    stripped_template = replace_sheet_bytes(
+        template_bytes,
+        ET.tostring(root, encoding="utf-8", xml_declaration=True),
+    )
+
+    result = testcases.populate_testcase_list(stripped_template, csv_text)
+
+    with zipfile.ZipFile(io.BytesIO(result), "r") as archive:
+        updated_sheet = archive.read("xl/worksheets/sheet1.xml")
+
+    updated_root = ET.fromstring(updated_sheet)
+    updated_dimension = updated_root.find("s:dimension", ns)
+
+    assert updated_dimension is not None
+    ref = (updated_dimension.get("ref") or "").strip()
+    assert ref
+    assert re.fullmatch(r"[A-Z]+\d+:[A-Z]+\d+", ref)


### PR DESCRIPTION
## Summary
- track when worksheet dimensions are inferred because the template lacks a <dimension> tag
- insert the missing <dimension> element ahead of sheetData during serialization
- add a regression test covering templates with missing dimensions

## Testing
- pytest backend/tests/test_excel_testcases.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910208a740c8330b95932a2bd4b7165)