### PR TITLE
Restore worksheet dimension metadata when missing

### DIFF
--- a/backend/app/services/excel_templates/workbook.py
+++ b/backend/app/services/excel_templates/workbook.py
@@ -231,7 +231,7 @@ class WorksheetPopulator:
 
         self._preserve_dimension = preserve_dimension
         self._dimension = self._root.find("s:dimension", self._ns)
-        self._dimension_was_missing = self._dimension is None
+        self._dimension_inferred_ref: str | None = None
         ref = ""
         if self._dimension is not None:
             ref = (self._dimension.get("ref") or "").strip()
@@ -240,6 +240,8 @@ class WorksheetPopulator:
             ref = self._infer_dimension()
             if not ref:
                 raise ValueError("워크시트 범위 정보를 찾을 수 없습니다.")
+            if self._dimension is None:
+                self._dimension_inferred_ref = ref
 
         (
             self._dimension_start_col,
@@ -380,6 +382,8 @@ class WorksheetPopulator:
                 break
         if not inserted:
             row.append(new_cell)
+        if column_to_index(self._dimension_end_col) < target_index:
+            self._dimension_end_col = column
         return new_cell
 
     def populate(self, records: Sequence[Dict[str, str]]) -> None:
@@ -408,12 +412,7 @@ class WorksheetPopulator:
         if last_row > self._dimension_end_row:
             self._dimension_end_row = last_row
 
-        if self._dimension is not None and self._preserve_dimension:
-            self._dimension.set(
-                "ref",
-                f"{self._dimension_start_col}{self._dimension_start_row}:{self._dimension_end_col}{self._dimension_end_row}",
-            )
-        self._dimension_was_missing = self._dimension is None and self._dimension_was_missing
+        self._update_dimension_metadata()
 
     def _merge_tag(self, name: str) -> str:
         return f"{{{SPREADSHEET_NS}}}{name}"
@@ -536,7 +535,39 @@ class WorksheetPopulator:
             str(len(merge_container.findall("s:mergeCell", self._ns))),
         )
 
+    def _latest_dimension_ref(self) -> str:
+        return (
+            f"{self._dimension_start_col}{self._dimension_start_row}:"
+            f"{self._dimension_end_col}{self._dimension_end_row}"
+        )
+
+    def _insert_before_sheet_data(self, element: ET.Element) -> None:
+        for idx, child in enumerate(list(self._root)):
+            if child.tag == self._tag("sheetData"):
+                self._root.insert(idx, element)
+                return
+        self._root.insert(0, element)
+
+    def _update_dimension_metadata(self) -> None:
+        latest_ref = self._latest_dimension_ref()
+        self._dimension_inferred_ref = latest_ref
+
+        if not self._preserve_dimension:
+            return
+
+        if self._dimension is not None:
+            self._dimension.set("ref", latest_ref)
+            return
+
+        if not self._dimension_inferred_ref:
+            return
+
+        dimension = ET.Element(self._tag("dimension"), {"ref": latest_ref})
+        self._insert_before_sheet_data(dimension)
+        self._dimension = dimension
+
     def to_bytes(self) -> bytes:
+        self._update_dimension_metadata()
         if not self._preserve_dimension and self._dimension is not None:
             self._root.remove(self._dimension)
             self._dimension = None

--- a/backend/tests/test_excel_defect_report.py
+++ b/backend/tests/test_excel_defect_report.py
@@ -12,6 +12,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.services.excel_templates import defect_report
+from app.services.excel_templates.models import SPREADSHEET_NS
 from app.services.excel_templates.utils import AI_CSV_DELIMITER
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "data" / "excel_templates"
@@ -30,17 +31,50 @@ def test_populate_defect_report_matches_fixture() -> None:
     assert hashlib.sha256(result).hexdigest() == expected_hash
 
 
-def test_populate_defect_report_excludes_dimension() -> None:
+def test_populate_defect_report_restores_missing_dimension() -> None:
     template_bytes = TEMPLATE_PATH.read_bytes()
     csv_text = (FIXTURE_DIR / "defect_report.csv").read_text(encoding="utf-8")
     if AI_CSV_DELIMITER != ",":
         csv_text = csv_text.replace(",", AI_CSV_DELIMITER)
 
-    result = defect_report.populate_defect_report(template_bytes, csv_text)
+    stripped_buffer = io.BytesIO()
+    original_dimension_ref: str | None = None
+    with zipfile.ZipFile(io.BytesIO(template_bytes), "r") as source, zipfile.ZipFile(
+        stripped_buffer, "w"
+    ) as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == "xl/worksheets/sheet1.xml":
+                root = ET.fromstring(data)
+                ns = {"s": SPREADSHEET_NS}
+                dimension = root.find("s:dimension", ns)
+                if dimension is not None:
+                    original_dimension_ref = dimension.get("ref")
+                    root.remove(dimension)
+                data = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+            target.writestr(info, data)
+
+    assert original_dimension_ref is not None
+    stripped_template = stripped_buffer.getvalue()
+    result = defect_report.populate_defect_report(stripped_template, csv_text)
 
     with zipfile.ZipFile(io.BytesIO(result), "r") as archive:
-        sheet_xml = archive.read("xl/worksheets/sheet1.xml")
+        updated_sheet = archive.read("xl/worksheets/sheet1.xml")
 
     ns = {"s": SPREADSHEET_NS}
-    root = ET.fromstring(sheet_xml)
-    assert root.find("s:dimension", ns) is None
+    updated_root = ET.fromstring(updated_sheet)
+    dimension = updated_root.find("s:dimension", ns)
+    assert dimension is not None, "Expected <dimension> to be restored"
+    assert dimension.get("ref") == original_dimension_ref
+
+    children = list(updated_root)
+    dimension_index = next(
+        (idx for idx, child in enumerate(children) if child.tag == f"{{{SPREADSHEET_NS}}}dimension"),
+        None,
+    )
+    sheet_data_index = next(
+        (idx for idx, child in enumerate(children) if child.tag == f"{{{SPREADSHEET_NS}}}sheetData"),
+        None,
+    )
+    assert dimension_index is not None and sheet_data_index is not None
+    assert dimension_index < sheet_data_index


### PR DESCRIPTION
## Summary
- track inferred worksheet dimensions when templates are missing the <dimension> element
- insert a <dimension> node before <sheetData> using the latest bounds during population/serialization
- update the defect report test to cover templates with stripped dimension metadata

## Testing
- pytest backend/tests/test_excel_defect_report.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910549a36908330921d8d77847dbc2d)