### PR TITLE
Remove forced dimension injection for defect reports

### DIFF
--- a/backend/app/services/excel_templates/workbook.py
+++ b/backend/app/services/excel_templates/workbook.py
@@ -231,7 +231,6 @@ class WorksheetPopulator:
 
         self._preserve_dimension = preserve_dimension
         self._dimension = self._root.find("s:dimension", self._ns)
-        self._dimension_was_missing = self._dimension is None
         ref = ""
         if self._dimension is not None:
             ref = (self._dimension.get("ref") or "").strip()
@@ -380,6 +379,8 @@ class WorksheetPopulator:
                 break
         if not inserted:
             row.append(new_cell)
+        if column_to_index(self._dimension_end_col) < target_index:
+            self._dimension_end_col = column
         return new_cell
 
     def populate(self, records: Sequence[Dict[str, str]]) -> None:
@@ -408,12 +409,7 @@ class WorksheetPopulator:
         if last_row > self._dimension_end_row:
             self._dimension_end_row = last_row
 
-        if self._dimension is not None and self._preserve_dimension:
-            self._dimension.set(
-                "ref",
-                f"{self._dimension_start_col}{self._dimension_start_row}:{self._dimension_end_col}{self._dimension_end_row}",
-            )
-        self._dimension_was_missing = self._dimension is None and self._dimension_was_missing
+        self._update_dimension_metadata()
 
     def _merge_tag(self, name: str) -> str:
         return f"{{{SPREADSHEET_NS}}}{name}"
@@ -536,7 +532,24 @@ class WorksheetPopulator:
             str(len(merge_container.findall("s:mergeCell", self._ns))),
         )
 
+    def _latest_dimension_ref(self) -> str:
+        return (
+            f"{self._dimension_start_col}{self._dimension_start_row}:"
+            f"{self._dimension_end_col}{self._dimension_end_row}"
+        )
+
+    def _update_dimension_metadata(self) -> None:
+        if not self._preserve_dimension:
+            return
+
+        if self._dimension is None:
+            return
+
+        latest_ref = self._latest_dimension_ref()
+        self._dimension.set("ref", latest_ref)
+
     def to_bytes(self) -> bytes:
+        self._update_dimension_metadata()
         if not self._preserve_dimension and self._dimension is not None:
             self._root.remove(self._dimension)
             self._dimension = None

--- a/backend/tests/test_excel_defect_report.py
+++ b/backend/tests/test_excel_defect_report.py
@@ -12,6 +12,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.services.excel_templates import defect_report
+from app.services.excel_templates.models import SPREADSHEET_NS
 from app.services.excel_templates.utils import AI_CSV_DELIMITER
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "data" / "excel_templates"
@@ -30,17 +31,33 @@ def test_populate_defect_report_matches_fixture() -> None:
     assert hashlib.sha256(result).hexdigest() == expected_hash
 
 
-def test_populate_defect_report_excludes_dimension() -> None:
+def test_populate_defect_report_does_not_inject_dimension() -> None:
     template_bytes = TEMPLATE_PATH.read_bytes()
     csv_text = (FIXTURE_DIR / "defect_report.csv").read_text(encoding="utf-8")
     if AI_CSV_DELIMITER != ",":
         csv_text = csv_text.replace(",", AI_CSV_DELIMITER)
 
-    result = defect_report.populate_defect_report(template_bytes, csv_text)
+    stripped_buffer = io.BytesIO()
+    dimension_tag = f"{{{SPREADSHEET_NS}}}dimension"
+    with zipfile.ZipFile(io.BytesIO(template_bytes), "r") as source, zipfile.ZipFile(
+        stripped_buffer, "w"
+    ) as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == "xl/worksheets/sheet1.xml":
+                root = ET.fromstring(data)
+                dimension = root.find(dimension_tag)
+                if dimension is not None:
+                    root.remove(dimension)
+                data = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+            target.writestr(info, data)
+
+    stripped_template = stripped_buffer.getvalue()
+    result = defect_report.populate_defect_report(stripped_template, csv_text)
 
     with zipfile.ZipFile(io.BytesIO(result), "r") as archive:
-        sheet_xml = archive.read("xl/worksheets/sheet1.xml")
+        updated_sheet = archive.read("xl/worksheets/sheet1.xml")
 
-    ns = {"s": SPREADSHEET_NS}
-    root = ET.fromstring(sheet_xml)
-    assert root.find("s:dimension", ns) is None
+    updated_root = ET.fromstring(updated_sheet)
+    dimension = updated_root.find(dimension_tag)
+    assert dimension is None, "<dimension> should not be injected"


### PR DESCRIPTION
## Summary
- remove the logic that injects a <dimension> element when worksheets are missing metadata
- retain dimension ref updates only for existing nodes
- adjust the defect report regression test to confirm no <dimension> element is added when the template lacks one

## Testing
- pytest backend/tests/test_excel_defect_report.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910549a36908330921d8d77847dbc2d)