### PR TITLE
Ensure OpenPyXL defect reports omit dimension tag

### DIFF
--- a/backend/app/services/excel_templates.py
+++ b/backend/app/services/excel_templates.py
@@ -8,6 +8,11 @@ import zipfile
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Mapping, Sequence, Tuple, Optional
 
+try:
+    from .excel_templates.defect_report import _remove_dimension_tag as _xml_remove_dimension_tag  # type: ignore
+except Exception:  # pragma: no cover - legacy module import fallback
+    _xml_remove_dimension_tag = None  # type: ignore
+
 from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.drawing.image import Image as XLImage
@@ -618,11 +623,74 @@ def _set_row_values(ws: Worksheet, row_index: int, record: Dict[str, str], colum
         raw = record.get(spec.key, "")
         ws[f"{spec.letter}{row_index}"].value = _sanitize_xml_text(str(raw or ""))
 
-def _wb_to_bytes(wb) -> bytes:
+def _remove_dimension_from_sheet_xml(sheet_bytes: bytes) -> tuple[bytes, bool]:
+    if not sheet_bytes:
+        return sheet_bytes, False
+
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.fromstring(sheet_bytes)
+    except ET.ParseError:
+        return sheet_bytes, False
+
+    ns = {"s": _S_NS}
+    has_dimension = root.find("s:dimension", ns) is not None
+    if not has_dimension:
+        return sheet_bytes, False
+
+    if _xml_remove_dimension_tag is None:  # pragma: no cover - defensive fallback
+        return sheet_bytes, False
+
+    _xml_remove_dimension_tag(root)
+    updated = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return updated, True
+
+
+def _remove_dimension_from_workbook(xlsx_bytes: bytes) -> bytes:
+    try:
+        buffer = io.BytesIO(xlsx_bytes)
+        if not zipfile.is_zipfile(buffer):
+            return xlsx_bytes
+        buffer.seek(0)
+        with zipfile.ZipFile(buffer, "r") as zin:
+            entries: List[Tuple[zipfile.ZipInfo, bytes]] = []
+            changed = False
+            for info in zin.infolist():
+                data = zin.read(info.filename)
+                if info.filename == "xl/worksheets/sheet1.xml":
+                    new_data, removed = _remove_dimension_from_sheet_xml(data)
+                    if removed:
+                        data = new_data
+                        changed = True
+                entries.append((info, data))
+
+        if not changed:
+            return xlsx_bytes
+
+        out = io.BytesIO()
+        with zipfile.ZipFile(out, "w") as zout:
+            for info, data in entries:
+                zout.writestr(info, data)
+        return out.getvalue()
+    except Exception:  # pragma: no cover - defensive
+        return xlsx_bytes
+
+
+def _wb_to_bytes(wb, *, ensure_dimension_removed: bool = False) -> bytes:
     bio = io.BytesIO()
     wb.save(bio)
-    # 저장 직후 Windows Excel 호환 수리 수행
-    return _repair_package(bio.getvalue())
+    raw_bytes = bio.getvalue()
+
+    if ensure_dimension_removed:
+        raw_bytes = _remove_dimension_from_workbook(raw_bytes)
+
+    repaired = _repair_package(raw_bytes)
+
+    if ensure_dimension_removed:
+        repaired = _remove_dimension_from_workbook(repaired)
+
+    return repaired
 
 
 # --------------------- 공개 API: 표 채우기 ---------------------
@@ -756,7 +824,13 @@ def populate_defect_report(
             vertical_gap_px=4,
         )
 
-    return _wb_to_bytes(wb)
+    try:
+        if hasattr(ws, "calculate_dimension"):
+            setattr(ws, "calculate_dimension", None)
+    except Exception:  # pragma: no cover - best effort cleanup
+        pass
+
+    return _wb_to_bytes(wb, ensure_dimension_removed=True)
 
 
 def populate_security_report(workbook_bytes: bytes, csv_text: str) -> bytes:

--- a/backend/tests/test_excel_population.py
+++ b/backend/tests/test_excel_population.py
@@ -434,6 +434,35 @@ def test_populate_defect_report_injects_images_with_relationship_namespace() -> 
     assert b"<dimension" not in sheet_xml
 
 
+def test_populate_defect_report_removes_dimension_tag() -> None:
+    template_path = Path("backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx")
+    template_bytes = template_path.read_bytes()
+
+    header = "|".join(DEFECT_REPORT_EXPECTED_HEADERS)
+    row = "|".join(
+        [
+            "1",
+            "Windows",
+            "요약",
+            "High",
+            "Frequent",
+            "품질",
+            "설명",
+            "응답",
+            "수정",
+            "비고",
+        ]
+    )
+    csv_text = f"{header}\n{row}"
+
+    workbook_bytes = populate_defect_report(template_bytes, csv_text)
+
+    with zipfile.ZipFile(io.BytesIO(workbook_bytes), "r") as zf:
+        sheet_xml = zf.read("xl/worksheets/sheet1.xml")
+
+    assert b"<dimension" not in sheet_xml
+
+
 def test_populate_defect_report_accepts_spaced_headers() -> None:
     template_path = Path("backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx")
     template_bytes = template_path.read_bytes()


### PR DESCRIPTION
## Summary
- strip the <dimension> element from the OpenPyXL defect report sheet before and after repairing the workbook package
- disable the worksheet dimension writer prior to saving so the tag is not regenerated
- add a regression test that verifies xl/worksheets/sheet1.xml has no <dimension> tag when populated via the OpenPyXL path

## Testing
- python - <<'PY'
import sys, io, zipfile
from pathlib import Path
sys.path.insert(0, 'backend')
from app.services.excel_templates import populate_defect_report, DEFECT_REPORT_EXPECTED_HEADERS

template_path = Path('backend/template/다.수행/GS-B-2X-XXXX 결함리포트 v1.0.xlsx')
header = "|".join(DEFECT_REPORT_EXPECTED_HEADERS)
row = "|".join(["1","Windows","요약","High","Frequent","품질","설명","응답","수정","비고"])
csv_text = f"{header}\n{row}"
workbook_bytes = populate_defect_report(template_path.read_bytes(), csv_text)
with zipfile.ZipFile(io.BytesIO(workbook_bytes), 'r') as zf:
    sheet_xml = zf.read('xl/worksheets/sheet1.xml')
assert b'<dimension' not in sheet_xml
PY
- pytest backend/tests/test_excel_population.py::test_populate_defect_report_removes_dimension_tag

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108b7596a88330a6b3939218855f00)